### PR TITLE
Feat/object config

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -18,7 +18,11 @@ jobs:
           php-version: 7.4
 
       - name: Install Dependencies
-        run: composer update --ignore-platform-reqs
+        run: |
+          # copy common.config.php for composer autoloader
+          cp core/config/common.config.sample.php  core/config/common.config.php 
+          # install composer dependencies
+          composer update --ignore-platform-reqs
 
       - name: Setup PHP 8.2 for PHPStan
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -2,7 +2,7 @@ name: PHPStan
 
 on:
   push:
-    branches: [ alpha ]
+    branches: [ alpha, feat/object_config ]
   pull_request:
     branches: [ alpha ]
 
@@ -25,7 +25,11 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install Dependencies
-        run: composer update --ignore-platform-reqs
+        run: |
+          # copy common.config.php for composer autoloader
+          cp core/config/common.config.sample.php  core/config/common.config.php 
+          # install composer dependencies
+          composer update --ignore-platform-reqs
 
       - name: Restore PHPStan cache
         id: cache-phpstan

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -9,25 +9,23 @@ on:
 jobs:
   phpstan:
     runs-on: ubuntu-latest
+    # define every php version to test
+    strategy:
+      # do not stop at first fail
+      fail-fast: false
+      matrix:
+        php: [7.4, 8.2]
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP 7.4 for dependencies
+      - name: Setup PHP ${{ matrix.php }} for dependencies
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php }}
 
       - name: Install Dependencies
-        run: |
-          # copy common.config.php for composer autoloader
-          cp core/config/common.config.sample.php  core/config/common.config.php 
-          # install composer dependencies
-          composer update --ignore-platform-reqs
-
-      - name: Setup PHP 8.2 for PHPStan
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
+        run: composer update --ignore-platform-reqs
 
       - name: Restore PHPStan cache
         id: cache-phpstan
@@ -36,12 +34,8 @@ jobs:
           path: phpstan.phar
           key: phpstan-1
 
-      - name: Download PHPStan
-        if: steps.cache-phpstan.outputs.cache-hit != 'true'
-        run: wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-
       - name: Run PHPStan
-        run: php phpstan.phar analyse --configuration phpstan.neon
+        run: vendor/bin/phpstan analyse --configuration phpstan.neon
 
   update-baseline:
     needs: phpstan
@@ -54,9 +48,7 @@ jobs:
 
       - name: Delete existing branch if exists
         run: |
-          if git ls-remote --heads origin update-phpstan-baseline | grep update-phpstan-baseline; then
-            git push origin --delete update-phpstan-baseline
-          fi
+          git ls-remote --exit-code --heads origin update-phpstan-baseline && git push origin --delete update-phpstan-baseline
 
       - name: Setup PHP 7.4 for dependencies
         uses: shivammathur/setup-php@v2
@@ -66,19 +58,11 @@ jobs:
       - name: Install Dependencies
         run: composer update --ignore-platform-reqs
 
-      - name: Setup PHP 8.2 for PHPStan
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-
-      - name: Download PHPStan
-        run: wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-
       - name: Generate new baseline
         id: generate-baseline
         run: |
           cp phpstan-baseline.neon phpstan-baseline.neon.old
-          php phpstan.phar analyse --configuration phpstan.neon --generate-baseline
+          vendor/bin/phpstan analyse --configuration phpstan.neon --generate-baseline
           if ! diff -q phpstan-baseline.neon phpstan-baseline.neon.old > /dev/null; then
             echo "baseline_changed=true" >> $GITHUB_OUTPUT
           fi

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,21 @@
     "platform": {
       "php": "7.4"
     }
+  },
+  "autoload": {
+    "psr-4": {
+      "Jeedom\\plugins\\": "plugins/"
+    },
+    "files": [
+      "core/config/common.config.php",
+      "core/php/utils.inc.php",
+      "core/config/jeedom.config.php",
+      "core/config/compatibility.config.php"
+    ],
+    "classmap": [
+      "core/class/",
+      "core/com/",
+      "core/repo/"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
       "php": "7.4"
     }
   },
+  "require-dev": {
+    "phpstan/phpstan": "^2.1"
+  },
   "autoload": {
     "psr-4": {
       "Jeedom\\plugins\\": "plugins/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d3817ee337cc5ed162b1e9463030e8a",
+    "content-hash": "d2faa51c0ec5175dc36b46b3356938d9",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -243,16 +243,16 @@
         },
         {
             "name": "influxdata/influxdb-client-php",
-            "version": "3.6.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/influxdata/influxdb-client-php.git",
-                "reference": "3606b12214508f22126b7ed0565d53380674312a"
+                "reference": "59ac11d63ce030973c79d5b05797813761a0d58e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/influxdata/influxdb-client-php/zipball/3606b12214508f22126b7ed0565d53380674312a",
-                "reference": "3606b12214508f22126b7ed0565d53380674312a",
+                "url": "https://api.github.com/repos/influxdata/influxdb-client-php/zipball/59ac11d63ce030973c79d5b05797813761a0d58e",
+                "reference": "59ac11d63ce030973c79d5b05797813761a0d58e",
                 "shasum": ""
             },
             "require": {
@@ -287,9 +287,9 @@
             ],
             "support": {
                 "issues": "https://github.com/influxdata/influxdb-client-php/issues",
-                "source": "https://github.com/influxdata/influxdb-client-php/tree/3.6.0"
+                "source": "https://github.com/influxdata/influxdb-client-php/tree/3.8.0"
             },
-            "time": "2024-06-24T10:01:53+00:00"
+            "time": "2025-06-26T05:12:59+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -1487,7 +1487,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -1543,7 +1543,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -1563,16 +1563,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -1623,7 +1623,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -1639,7 +1639,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1856,7 +1856,66 @@
             "time": "2022-06-03T18:03:27+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1ccf445757458c06a04eb3f803603cb118fe5fa6",
+                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-28T19:35:08+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},

--- a/core/ajax/cache.ajax.php
+++ b/core/ajax/cache.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init();
@@ -54,7 +54,7 @@ try {
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -29,7 +29,7 @@ try {
 	if (init('action') == 'getWidgetHelp') {
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue - Vérifiez l\'id', __FILE__));
+			throw new Exception(new Trad('Commande inconnue - Vérifiez l\'id', __FILE__));
 		}
 		$info_cmd = array();
 		$info_cmd['id'] = $cmd->getId();
@@ -54,7 +54,7 @@ try {
 		} else {
 			$cmd = cmd::byId(init('id'));
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande inconnue - Vérifiez l\'id', __FILE__));
+				throw new Exception(new Trad('Commande inconnue - Vérifiez l\'id', __FILE__));
 			}
 			$info_cmd = array();
 			$info_cmd['id'] = $cmd->getId();
@@ -69,7 +69,7 @@ try {
 		foreach ($cmds as $id) {
 			$cmd = cmd::byId($id);
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande inconnue. Vérifiez l\'ID', __FILE__) . ' ' . $id);
+				throw new Exception(new Trad('Commande inconnue. Vérifiez l\'ID', __FILE__) . ' ' . $id);
 			}
 			$cmd->setIsVisible(init('isVisible'));
 			$cmd->save(true);
@@ -80,17 +80,17 @@ try {
 	if (init('action') == 'execCmd') {
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
 		}
 		$eqLogic = $cmd->getEqLogic();
 		if ($cmd->getType() == 'action' && !$eqLogic->hasRight('x')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		if (!$cmd->checkAccessCode(init('codeAccess'))) {
-			throw new Exception(__('Cette action nécessite un code d\'accès', __FILE__), -32005);
+			throw new Exception(new Trad('Cette action nécessite un code d\'accès', __FILE__), -32005);
 		}
 		if ($cmd->getType() == 'action' && $cmd->getConfiguration('actionConfirm') == 1 && init('confirmAction') != 1) {
-			throw new Exception(__('Cette action nécessite une confirmation', __FILE__), -32006);
+			throw new Exception(new Trad('Cette action nécessite une confirmation', __FILE__), -32006);
 		}
 		$options = is_json(init('value'), array());
 		if (init('user_login') != '') {
@@ -105,7 +105,7 @@ try {
 	if (init('action') == 'getByObjectNameEqNameCmdName') {
 		$cmd = cmd::byObjectNameEqLogicNameCmdName(init('object_name'), init('eqLogic_name'), init('cmd_name'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('object_name') . '/' . init('eqLogic_name') . '/' . init('cmd_name'));
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('object_name') . '/' . init('eqLogic_name') . '/' . init('cmd_name'));
 		}
 		ajax::success($cmd->getId());
 	}
@@ -113,7 +113,7 @@ try {
 	if (init('action') == 'getByObjectNameCmdName') {
 		$cmd = cmd::byObjectNameCmdName(init('object_name'), init('cmd_name'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('object_name') . '/' . init('cmd_name'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('object_name') . '/' . init('cmd_name'), 9999);
 		}
 		ajax::success(utils::o2a($cmd));
 	}
@@ -121,14 +121,14 @@ try {
 	if (init('action') == 'byId') {
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
 		}
 		ajax::success(jeedom::toHumanReadable(utils::o2a($cmd)));
 	}
 
 	if (init('action') == 'copyHistoryToCmd') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		ajax::success(history::copyHistoryToCmd(init('source_id'), init('target_id')));
@@ -136,7 +136,7 @@ try {
 
 	if (init('action') == 'replaceCmd') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		ajax::success(jeedom::replaceTag(array('#' . str_replace('#', '', init('source_id')) . '#' => '#' . str_replace('#', '', init('target_id')) . '#')));
@@ -146,18 +146,18 @@ try {
 		$cmd_id = cmd::humanReadableToCmd(init('humanName'));
 		$cmd = cmd::byId(str_replace('#', '', $cmd_id));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('humanName'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('humanName'), 9999);
 		}
 		ajax::success(utils::o2a($cmd));
 	}
 
 	if (init('action') == 'usedBy') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
 		}
 		$result = $cmd->getUsedBy();
 		$return = array('cmd' => array(), 'eqLogic' => array(), 'scenario' => array(), 'plan' => array(), 'view' => array(), 'interactDef' => array());
@@ -207,36 +207,36 @@ try {
 
 	if (init('action') == 'dropInflux') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$cmd = cmd::byId(init('cmd_id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
 		}
 		ajax::success($cmd->dropInflux());
 	}
 
 	if (init('action') == 'historyInflux') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$cmd = cmd::byId(init('cmd_id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('id'), 9999);
 		}
 		ajax::success($cmd->historyInflux());
 	}
 
 	if (init('action') == 'dropDatabaseInflux') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(cmd::dropInfluxDatabase());
 	}
 
 	if (init('action') == 'historyInfluxAll') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(cmd::historyInfluxAll());
 	}
@@ -256,7 +256,7 @@ try {
 	if (init('action') == 'getCmd') {
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande inconnue :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Commande inconnue :', __FILE__) . ' ' . init('id'));
 		}
 		$return = jeedom::toHumanReadable(utils::o2a($cmd));
 		$eqLogic = $cmd->getEqLogic();
@@ -270,7 +270,7 @@ try {
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$cmd_ajax = jeedom::fromHumanReadable(json_decode(init('cmd'), true));
@@ -290,7 +290,7 @@ try {
 
 	if (init('action') == 'multiSave') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$cmds = json_decode(init('cmd'), true);
@@ -307,7 +307,7 @@ try {
 
 	if (init('action') == 'changeHistoryPoint') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'));
@@ -324,7 +324,7 @@ try {
 			$history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'), date('Y-m-d H:i:s', strtotime(init('datetime') . ' +1 month')), init('oldValue'));
 		}
 		if (!is_object($history)) {
-			throw new Exception(__('Aucun point ne correspond pour l\'historique :', __FILE__) . ' ' . init('cmd_id') . ' - ' . init('datetime'), init('oldValue'));
+			throw new Exception(new Trad('Aucun point ne correspond pour l\'historique :', __FILE__) . ' ' . init('cmd_id') . ' - ' . init('datetime'), init('oldValue'));
 		}
 		$value = init('value', null);
 		if ($value === '') {
@@ -405,7 +405,7 @@ try {
 		if (is_numeric(init('id'))) {
 			$cmd = cmd::byId(init('id'));
 			if (!is_object($cmd)) {
-				throw new Exception(__('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
+				throw new Exception(new Trad('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
 			}
 			$usage = $cmd->getCache('usage::history', 0);
 			$cmd->setCache('usage::history', $usage + 1);
@@ -414,7 +414,7 @@ try {
 
 			$eqLogic = $cmd->getEqLogic();
 			if (!$eqLogic->hasRight('r')) {
-				throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+				throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 			}
 			$derive = init('derive', $cmd->getDisplay('graphDerive'));
 			if (trim($derive) == '') {
@@ -500,18 +500,18 @@ try {
 		if(is_object($cmd)){
 			ajax::success($cmd->getLastHistory($_time));
 		} else {
-			throw new Exception(__('Nombre maximum de niveaux d’éléments affichés dans les graphiques de liens', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Nombre maximum de niveaux d’éléments affichés dans les graphiques de liens', __FILE__) . ' ' . init('id'));
 		}
 	}
 
 	if (init('action') == 'emptyHistory') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 		}
 		unautorizedInDemo();
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('ID de commande inconnu :', __FILE__) . ' ' . init('id'));
 		}
 		$cmd->emptyHistory(init('date'));
 		ajax::success();
@@ -555,16 +555,16 @@ try {
 
 	if (init('action') == 'getDeadCmd') {
 		$return = array(
-			'core' => array('cmd' => jeedom::deadCmd(), 'name' => __('Jeedom', __FILE__)),
-			'cmd' => array('cmd' => cmd::deadCmd(), 'name' => __('Commande', __FILE__)),
-			'jeeObject' => array('cmd' => jeeObject::deadCmd(), 'name' => __('Objet', __FILE__)),
-			'scenario' => array('cmd' => scenario::consystencyCheck(true), 'name' => __('Scénario', __FILE__)),
-			'interactDef' => array('cmd' => interactDef::deadCmd(), 'name' => __('Interaction', __FILE__)),
-			'user' => array('cmd' => user::deadCmd(), 'name' => __('Utilisateur', __FILE__)),
+			'core' => array('cmd' => jeedom::deadCmd(), 'name' => new Trad('Jeedom', __FILE__)),
+			'cmd' => array('cmd' => cmd::deadCmd(), 'name' => new Trad('Commande', __FILE__)),
+			'jeeObject' => array('cmd' => jeeObject::deadCmd(), 'name' => new Trad('Objet', __FILE__)),
+			'scenario' => array('cmd' => scenario::consystencyCheck(true), 'name' => new Trad('Scénario', __FILE__)),
+			'interactDef' => array('cmd' => interactDef::deadCmd(), 'name' => new Trad('Interaction', __FILE__)),
+			'user' => array('cmd' => user::deadCmd(), 'name' => new Trad('Utilisateur', __FILE__)),
 		);
 		foreach (plugin::listPlugin(true) as $plugin) {
 			$plugin_id = $plugin->getId();
-			$return[$plugin_id] =  array('cmd' => array(), 'name' => __('Plugin', __FILE__) . ' ' . $plugin->getName());
+			$return[$plugin_id] =  array('cmd' => array(), 'name' => new Trad('Plugin', __FILE__) . ' ' . $plugin->getName());
 			if (method_exists($plugin_id, 'deadCmd')) {
 				$return[$plugin_id]['cmd'] = $plugin_id::deadCmd();
 			} else {
@@ -574,7 +574,7 @@ try {
 		ajax::success($return);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/config.ajax.php
+++ b/core/ajax/config.ajax.php
@@ -21,14 +21,14 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init(array('uploadImage'));
 
 	if (init('action') == 'genApiKey') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		if (init('plugin') == 'core') {
@@ -52,7 +52,7 @@ try {
 	if (init('action') == 'getKey') {
 		$keys = init('key');
 		if ($keys == '') {
-			throw new Exception(__('Aucune clef demandée', __FILE__));
+			throw new Exception(new Trad('Aucune clef demandée', __FILE__));
 		}
 		if (is_json($keys)) {
 			$keys = json_decode($keys, true);
@@ -68,7 +68,7 @@ try {
 
 	if (init('action') == 'addKey') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$values = json_decode(init('value'), true);
@@ -82,7 +82,7 @@ try {
 		unautorizedInDemo();
 		$keys = init('key');
 		if ($keys == '') {
-			throw new Exception(__('Aucune clef demandée', __FILE__));
+			throw new Exception(new Trad('Aucune clef demandée', __FILE__));
 		}
 		if (is_json($keys)) {
 			$keys = json_decode($keys, true);
@@ -98,7 +98,7 @@ try {
 
 	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 
@@ -107,14 +107,14 @@ try {
 		config::save($key, config::getDefaultConfiguration()['core'][$key]);
 
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.jpg', '.png'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 		}
 
 		$uploaddir = realpath(__DIR__ . '/../../data/backgrounds');
@@ -127,7 +127,7 @@ try {
 		@unlink($filepath);
 		file_put_contents($filepath, file_get_contents($_FILES['file']['tmp_name']));
 		if (!file_exists($filepath)) {
-			throw new Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 
 		config::save($key, '/data/backgrounds/config_' . $page . $extension);
@@ -136,7 +136,7 @@ try {
 
 	if (init('action') == 'removeImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 
@@ -149,7 +149,7 @@ try {
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/cron.ajax.php
+++ b/core/ajax/cron.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -36,7 +36,7 @@ try {
 		unautorizedInDemo();
 		$cron = cron::byId(init('id'));
 		if (!is_object($cron)) {
-			throw new Exception(__('Cron id inconnu', __FILE__));
+			throw new Exception(new Trad('Cron id inconnu', __FILE__));
 		}
 		$cron->remove();
 		ajax::success();
@@ -53,7 +53,7 @@ try {
 	if (init('action') == 'start') {
 		$cron = cron::byId(init('id'));
 		if (!is_object($cron)) {
-			throw new Exception(__('Cron id inconnu', __FILE__));
+			throw new Exception(new Trad('Cron id inconnu', __FILE__));
 		}
 		$cron->run();
 		sleep(1);
@@ -63,14 +63,14 @@ try {
 	if (init('action') == 'stop') {
 		$cron = cron::byId(init('id'));
 		if (!is_object($cron)) {
-			throw new Exception(__('Cron id inconnu', __FILE__));
+			throw new Exception(new Trad('Cron id inconnu', __FILE__));
 		}
 		$cron->halt();
 		sleep(1);
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/ajax/dataStore.ajax.php
+++ b/core/ajax/dataStore.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -29,7 +29,7 @@ try {
 	if (init('action') == 'remove') {
 		$dataStore = dataStore::byId(init('id'));
 		if (!is_object($dataStore)) {
-			throw new Exception(__('Dépôt de données inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Dépôt de données inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		$dataStore->remove();
 		ajax::success();
@@ -45,7 +45,7 @@ try {
 			$dataStore = dataStore::byId(init('id'));
 		}
 		if (!is_object($dataStore)) {
-			throw new Exception(__('Dépôt de données inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Dépôt de données inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		$dataStore->setValue(init('value'));
 		$dataStore->save();
@@ -88,7 +88,7 @@ try {
 		$key = trim(init('key'));
 		$dataStore = dataStore::byTypeLinkIdKey(init('type'), init('linkId'), $key);
 		if (!is_object($dataStore)) {
-			throw new Exception(__('Dépôt de données inconnu.', __FILE__) . $key);
+			throw new Exception(new Trad('Dépôt de données inconnu.', __FILE__) . $key);
 		}
 		$return = jeeAjax_datastoreReturn($dataStore, init('usedBy'));
 		ajax::success($return);
@@ -99,7 +99,7 @@ try {
 		ajax::success($return);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -21,30 +21,30 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('uploadImage'));
 
 	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (init('file') == '') {
 			if (!isset($_FILES['file'])) {
-				throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+				throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 			}
 			$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 			if (!in_array($extension, array('.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp'))) {
-				throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif .svg .webp) :', __FILE__) . ' ' . $extension);
+				throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png .gif .svg .webp) :', __FILE__) . ' ' . $extension);
 			}
 			if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-				throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+				throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 			}
 			$upfilepath = $_FILES['file']['tmp_name'];
 		} else {
@@ -64,7 +64,7 @@ try {
 		$filepath = __DIR__ . '/../../data/eqLogic/' . $filename;
 		file_put_contents($filepath, file_get_contents($upfilepath));
 		if (!file_exists($filepath)) {
-			throw new \Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new \Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 		$eqLogic->save(true);
 		ajax::success(array('filepath' => $eqLogic->getImage()));
@@ -72,12 +72,12 @@ try {
 
 	if (init('action') == 'removeImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		$eqLogic->getConfiguration('image::data', '');
 		$eqLogic->getConfiguration('image::sha512', '');
@@ -95,7 +95,7 @@ try {
 		$object = jeeObject::byId(init('object_id'));
 
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$return = utils::o2a($object);
 		$return['eqLogic'] = array();
@@ -115,7 +115,7 @@ try {
 	if (init('action') == 'byId') {
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		ajax::success(utils::o2a($eqLogic));
 	}
@@ -123,7 +123,7 @@ try {
 	if (init('action') == 'byLogical') {
 		$eqLogic = eqLogic::byLogicalId(init('logical'), init('type'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez le logicalId ou le type', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez le logicalId ou le type', __FILE__));
 		}
 		ajax::success(utils::o2a($eqLogic));
 	}
@@ -149,7 +149,7 @@ try {
 		} else {
 			$eqLogic = eqLogic::byId(init('id'));
 			if (!is_object($eqLogic)) {
-				throw new Exception(__('Eqlogic inconnu. Vérifiez l\'ID', __FILE__));
+				throw new Exception(new Trad('Eqlogic inconnu. Vérifiez l\'ID', __FILE__));
 			}
 			$info_eqLogic = array();
 			$info_eqLogic['id'] = $eqLogic->getId();
@@ -260,14 +260,14 @@ try {
 	if (init('action') == 'setIsEnable') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!$eqLogic->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$eqLogic->setIsEnable(init('isEnable'));
 		$eqLogic->save(true);
@@ -299,7 +299,7 @@ try {
 				continue;
 			}
 			if (!isset($eqLogic_json['generic_type'])) {
-				throw new Exception(__('Pas de Type Generic fourni', __FILE__));
+				throw new Exception(new Trad('Pas de Type Generic fourni', __FILE__));
 			}
 			$eqLogic = eqLogic::byId($eqLogic_json['id']);
 			if (!is_object($eqLogic)) {
@@ -318,7 +318,7 @@ try {
 		foreach ($eqLogics as $id) {
 			$eqLogic = eqLogic::byId($id);
 			if (!is_object($eqLogic)) {
-				throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
+				throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
 			}
 			if (!$eqLogic->hasRight('w')) {
 				continue;
@@ -334,7 +334,7 @@ try {
 		foreach ($eqLogics as $id) {
 			$eqLogic = eqLogic::byId($id);
 			if (!is_object($eqLogic)) {
-				throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
+				throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
 			}
 			if (!$eqLogic->hasRight('w')) {
 				continue;
@@ -351,7 +351,7 @@ try {
 		foreach ($eqLogics as $id) {
 			$eqLogic = eqLogic::byId($id);
 			if (!is_object($eqLogic)) {
-				throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
+				throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $id);
 			}
 			if (!$eqLogic->hasRight('w')) {
 				continue;
@@ -365,16 +365,16 @@ try {
 	if (init('action') == 'simpleSave') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$eqLogicSave = json_decode(init('eqLogic'), true);
 		$eqLogic = eqLogic::byId($eqLogicSave['id']);
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqLogicSave['id']);
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . $eqLogicSave['id']);
 		}
 
 		if (!$eqLogic->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		utils::a2o($eqLogic, $eqLogicSave);
 		$eqLogic->save();
@@ -384,14 +384,14 @@ try {
 	if (init('action') == 'copy') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (init('name') == '') {
-			throw new Exception(__('Le nom de la copie de l\'équipement ne peut être vide', __FILE__));
+			throw new Exception(new Trad('Le nom de la copie de l\'équipement ne peut être vide', __FILE__));
 		}
 		ajax::success(utils::o2a($eqLogic->copy(init('name'))));
 	}
@@ -400,7 +400,7 @@ try {
 		$used = array();
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$data = array('node' => array(), 'link' => array());
 		$data = $eqLogic->getLinkData($data, 0, 2);
@@ -439,11 +439,11 @@ try {
 
 	if (init('action') == 'usedBy') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('Equipement inconnu :', __FILE__) . ' ' . init('id'), 9999);
+			throw new Exception(new Trad('Equipement inconnu :', __FILE__) . ' ' . init('id'), 9999);
 		}
 		$result = $eqLogic->getUsedBy();
 		$return = array('cmd' => array(), 'eqLogic' => array(), 'scenario' => array(), 'plan' => array(), 'view' => array(), 'interactDef' => array());
@@ -494,14 +494,14 @@ try {
 	if (init('action') == 'remove') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		if (!$eqLogic->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$eqLogic->remove();
 		ajax::success();
@@ -510,11 +510,11 @@ try {
 	if (init('action') == 'get') {
 		$typeEqLogic = init('type');
 		if ($typeEqLogic == '' || !class_exists($typeEqLogic)) {
-			throw new Exception(__('Type incorrect (classe équipement inexistante) :', __FILE__) . ' ' . $typeEqLogic);
+			throw new Exception(new Trad('Type incorrect (classe équipement inexistante) :', __FILE__) . ' ' . $typeEqLogic);
 		}
 		$eqLogic = $typeEqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('EqLogic inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		$return = utils::o2a($eqLogic);
 		$return['cmd'] = array();
@@ -534,7 +534,7 @@ try {
 	if (init('action') == 'save') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 
 		$eqLogicSaves = init('eqLogic');
@@ -545,12 +545,12 @@ try {
 		foreach ($eqLogicsSave as $eqLogicSave) {
 
 			if (!is_array($eqLogicSave)) {
-				throw new Exception(__('Informations reçues incorrectes', __FILE__));
+				throw new Exception(new Trad('Informations reçues incorrectes', __FILE__));
 			}
 			$typeEqLogic = init('type');
 			$typeCmd = $typeEqLogic . 'Cmd';
 			if ($typeEqLogic == '' || !class_exists($typeEqLogic) || !class_exists($typeCmd)) {
-				throw new Exception(__('Type incorrect, (classe commande inexistante)', __FILE__) . $typeCmd);
+				throw new Exception(new Trad('Type incorrect, (classe commande inexistante)', __FILE__) . $typeCmd);
 			}
 			$eqLogic = null;
 			if (isset($eqLogicSave['id'])) {
@@ -561,7 +561,7 @@ try {
 				$eqLogic->setEqType_name(init('type'));
 			} else {
 				if (!$eqLogic->hasRight('w')) {
-					throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+					throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 				}
 			}
 			if (method_exists($eqLogic, 'preAjax')) {
@@ -621,7 +621,7 @@ try {
 		ajax::success($alerts);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/event.ajax.php
+++ b/core/ajax/event.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init();
@@ -30,7 +30,7 @@ try {
 		ajax::success(event::changes(init('datetime', 0), 59));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/history.ajax.php
+++ b/core/ajax/history.ajax.php
@@ -21,7 +21,7 @@ try {
   include_file('core', 'authentification', 'php');
   
   if (!isConnect()) {
-    throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+    throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
   }
   
   ajax::init();
@@ -31,7 +31,7 @@ try {
     ajax::success(history::removeHistoryInFutur());
   }
   
-  throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+  throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
   /*     * *********Catch exeption*************** */
 } catch (Exception $e) {
   ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/interact.ajax.php
+++ b/core/ajax/interact.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -69,7 +69,7 @@ try {
 
 	if (init('action') == 'autoCompleteGroup') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$return = array();
 		foreach (interactDef::listGroup(init('term')) as $group) {
@@ -87,7 +87,7 @@ try {
 		unautorizedInDemo();
 		$interact = interactDef::byId(init('id'));
 		if (!is_object($interact)) {
-			throw new Exception(__('Interaction inconnue. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Interaction inconnue. Vérifiez l\'ID', __FILE__));
 		}
 		$interact->remove();
 		ajax::success();
@@ -97,7 +97,7 @@ try {
 		unautorizedInDemo();
 		$interactQuery = interactQuery::byId(init('id'));
 		if (!is_object($interactQuery)) {
-			throw new Exception(__('InteractQuery ID inconnu', __FILE__));
+			throw new Exception(new Trad('InteractQuery ID inconnu', __FILE__));
 		}
 		$interactQuery->setEnable(init('enable'));
 		$interactQuery->save();
@@ -120,7 +120,7 @@ try {
 		ajax::success(interactQuery::tryToReply(init('query')));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/jeedom.ajax.php
+++ b/core/ajax/jeedom.ajax.php
@@ -38,14 +38,14 @@ try {
 
 		$return['language'] = config::byKey('language', 'core', 'fr_FR');
 		$return['userProfils'] = $_SESSION['user']->getOptions();
-		$return['userProfils']['defaultMobileViewName'] = __('Vue', __FILE__);
+		$return['userProfils']['defaultMobileViewName'] = new Trad('Vue', __FILE__);
 		if ($_SESSION['user']->getOptions('defaultDesktopView') != '') {
 			$view = view::byId($_SESSION['user']->getOptions('defaultDesktopView'));
 			if (is_object($view)) {
 				$return['userProfils']['defaultMobileViewName'] = $view->getName();
 			}
 		}
-		$return['userProfils']['defaultMobileObjectName'] = __('Objet', __FILE__);
+		$return['userProfils']['defaultMobileObjectName'] = new Trad('Objet', __FILE__);
 		if ($_SESSION['user']->getOptions('defaultDashboardObject') != '') {
 			$object = jeeObject::byId($_SESSION['user']->getOptions('defaultDashboardObject'));
 			if (is_object($object)) {
@@ -71,7 +71,7 @@ try {
 	}
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	if (init('action') == 'version') {
@@ -117,13 +117,13 @@ try {
 			$version = substr(jeedom::version(), 0, 3);
 			ajax::success(config::byKey('doc::base_url', 'core') . '/' . config::byKey('language', 'core', 'fr_FR') . '/core/' . $version . '/' . secureXSS($page) . '?theme=' . $theme);
 		}
-		throw new Exception(__('Aucune documentation trouvée', __FILE__), -1234);
+		throw new Exception(new Trad('Aucune documentation trouvée', __FILE__), -1234);
 	}
 
 	if (init('action') == 'addWarnme') {
 		$cmd = cmd::byId(init('cmd_id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande non trouvée :', __FILE__) . ' ' . init('cmd_id'));
+			throw new Exception(new Trad('Commande non trouvée :', __FILE__) . ' ' . init('cmd_id'));
 		}
 		$options = array(
 			'type' => 'cmd',
@@ -142,13 +142,13 @@ try {
 			$listener->save(true);
 			ajax::success();
 		} else {
-			throw new Exception(__('Aucune Commande de Notification :', __FILE__) . ' ' . init('cmd_id'));
+			throw new Exception(new Trad('Aucune Commande de Notification :', __FILE__) . ' ' . init('cmd_id'));
 			ajax::error();
 		}
 	}
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	if (init('action') == 'ssh') {
@@ -404,23 +404,23 @@ try {
 			mkdir($uploaddir);
 		}
 		if (!file_exists($uploaddir)) {
-			throw new Exception(__('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
+			throw new Exception(new Trad('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.gz'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .tar.gz) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .tar.gz) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 1000000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 1Go)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 1Go)', __FILE__));
 		}
 		if (!move_uploaded_file($_FILES['file']['tmp_name'], $uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de déplacer le fichier temporaire', __FILE__));
+			throw new Exception(new Trad('Impossible de déplacer le fichier temporaire', __FILE__));
 		}
 		if (!file_exists($uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
+			throw new Exception(new Trad('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
 		ajax::success();
 	}
@@ -464,107 +464,107 @@ try {
 		}
 		$object = $type::byId(init('filter_id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Type :', __FILE__) . init('filter_type') . ' ' . __('avec id :', __FILE__) . ' ' . init('filter_id') . ' ' . __('inconnu', __FILE__));
+			throw new Exception(new Trad('Type :', __FILE__) . init('filter_type') . ' ' . new Trad('avec id :', __FILE__) . ' ' . init('filter_id') . ' ' . new Trad('inconnu', __FILE__));
 		}
 		ajax::success($object->getLinkData());
 	}
 
 	if (init('action') == 'getFileFolder') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(ls($pathfile, '*', false, array(init('type'))));
 	}
 
 	if (init('action') == 'getFileContent') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$pathinfo = pathinfo(init('path'));
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
-			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
+			throw new Exception(new Trad('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(file_get_contents($pathfile));
 	}
 
 	if (init('action') == 'setFileContent') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$pathinfo = pathinfo(init('path'));
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
-			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
+			throw new Exception(new Trad('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(file_put_contents($pathfile, init('content')));
 	}
 
 	if (init('action') == 'deleteFile') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$pathinfo = pathinfo(init('path'));
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
-			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
+			throw new Exception(new Trad('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(unlink($pathfile));
 	}
 
 	if (init('action') == 'createFile') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$pathinfo = pathinfo(init('name'));
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
-			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
+			throw new Exception(new Trad('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		touch($pathfile . init('name'));
 		if (!file_exists($pathfile . init('name'))) {
-			throw new Exception(__('Impossible de créer le fichier, vérifiez les droits', __FILE__));
+			throw new Exception(new Trad('Impossible de créer le fichier, vérifiez les droits', __FILE__));
 		}
 		ajax::success();
 	}
@@ -573,11 +573,11 @@ try {
 		unautorizedInDemo();
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		mkdir($pathfile . '/' . init('name'));
 		ajax::success();
@@ -587,11 +587,11 @@ try {
 		unautorizedInDemo();
 		$pathfile = calculPath(init('src'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(rename($pathfile, init('dst')));
 	}
@@ -600,11 +600,11 @@ try {
 		unautorizedInDemo();
 		$pathfile = calculPath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$rootPath = realpath(__DIR__ . '/../../');
 		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(rrmdir($pathfile));
 	}
@@ -619,18 +619,18 @@ try {
 
 	if (init('action') == 'uploadImageIcon') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif .jpeg .svg .webp) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png .gif .jpeg .svg .webp) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 		}
 		$path = init('filepath');
 		if (!file_exists(__DIR__ . '/../../' . $path)) {
@@ -640,23 +640,23 @@ try {
 		$filepath = __DIR__ . '/../../' . $path . $filename;
 		file_put_contents($filepath, file_get_contents($_FILES['file']['tmp_name']));
 		if (!file_exists($filepath)) {
-			throw new \Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new \Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 		ajax::success(array('filepath' => $filepath));
 	}
 
 	if (init('action') == 'removeImageIcon') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$filepath = __DIR__ . '/../../' . init('filepath');
 		if (!file_exists($filepath)) {
-			throw new Exception(__('Fichier introuvable, impossible de le supprimer', __FILE__));
+			throw new Exception(new Trad('Fichier introuvable, impossible de le supprimer', __FILE__));
 		}
 		unlink($filepath);
 		if (file_exists($filepath)) {
-			throw new Exception(__('Impossible de supprimer le fichier', __FILE__));
+			throw new Exception(new Trad('Impossible de supprimer le fichier', __FILE__));
 		}
 		ajax::success();
 	}
@@ -690,7 +690,7 @@ try {
 		ajax::success(jeedom::massReplace(init('options', array()), init('eqlogics', array()), init('cmds', array())));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/listener.ajax.php
+++ b/core/ajax/listener.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -36,7 +36,7 @@ try {
 		unautorizedInDemo();
 		$listener = listener::byId(init('id'));
 		if (!is_object($listener)) {
-			throw new Exception(__('Listener id inconnu', __FILE__));
+			throw new Exception(new Trad('Listener id inconnu', __FILE__));
 		}
 		$listener->remove();
 		ajax::success();
@@ -54,7 +54,7 @@ try {
 		ajax::success($listeners);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/ajax/log.ajax.php
+++ b/core/ajax/log.ajax.php
@@ -25,7 +25,7 @@ try {
 	}
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -76,7 +76,7 @@ try {
 		);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/message.ajax.php
+++ b/core/ajax/message.ajax.php
@@ -21,14 +21,14 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
 
 	if (init('action') == 'clearMessage') {
 		if(!isConnect('admin')){
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
 		}
 		message::removeAll(init('plugin'));
 		ajax::success();
@@ -50,17 +50,17 @@ try {
 
 	if (init('action') == 'removeMessage') {
 		if(!isConnect('admin')){
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
 		}
 		$message = message::byId(init('id'));
 		if (!is_object($message)) {
-			throw new Exception(__('Message inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Message inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$message->remove();
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/network.ajax.php
+++ b/core/ajax/network.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 	
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 	
 	ajax::init();
@@ -45,7 +45,7 @@ try {
 		ajax::success(network::getInterfacesInfo());
 	}
 	
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/note.ajax.php
+++ b/core/ajax/note.ajax.php
@@ -22,28 +22,28 @@ try {
 	include_file('core', 'authentification', 'php');
 	
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 	
 	ajax::init();
 	
 	if (init('action') == 'all') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(utils::o2a(note::all()));
 	}
 	
 	if (init('action') == 'byId') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(utils::o2a(note::byId(init('id'))));
 	}
 	
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$note_json = json_decode(init('note'), true);
 		if (isset($note_json['id'])) {
@@ -59,11 +59,11 @@ try {
 	
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$note = note::byId(init('id'));
 		if (!is_object($note)) {
-			throw new Exception(__('Note inconnue. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Note inconnue. Vérifiez l\'ID', __FILE__));
 		}
 		$note->remove();
 		ajax::success();
@@ -71,7 +71,7 @@ try {
 	
 	ajax::init();
 	
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/object.ajax.php
+++ b/core/ajax/object.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('uploadImage'));
@@ -29,11 +29,11 @@ try {
 	if (init('action') == 'remove') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$object->remove();
 		ajax::success();
@@ -42,7 +42,7 @@ try {
 	if (init('action') == 'byId') {
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		ajax::success(jeedom::toHumanReadable(utils::o2a($object)));
 	}
@@ -70,7 +70,7 @@ try {
 	if (init('action') == 'save') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$object_json = json_decode(init('object'), true);
 		if (isset($object_json['id'])) {
@@ -87,11 +87,11 @@ try {
 	if (init('action') == 'orderEqLogicByUsage') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$object->orderEqLogicByUsage();
 		ajax::success(utils::o2a($object));
@@ -100,7 +100,7 @@ try {
 	if (init('action') == 'getChild') {
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$return = utils::o2a($object->getChild());
 		ajax::success($return);
@@ -113,7 +113,7 @@ try {
 			$virtual = eqLogic::byLogicalId('summary' . init('object_id'), 'virtual');
 		}
 		if (!is_object($virtual)) {
-			throw new Exception(__('L\'objet n\'existe pas :', __FILE__) . ' ' . init('object_id'));
+			throw new Exception(new Trad('L\'objet n\'existe pas :', __FILE__) . ' ' . init('object_id'));
 		}
 		$removeCmd = array();
 		foreach ($virtual->getCmd() as $cmd) {
@@ -131,7 +131,7 @@ try {
 	if (init('action') == 'getEqLogicsFromSummary') {
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		$return = $object->getEqLogicsFromSummary(init('summary'), init('onlyEnable'), init('onlyVisible'));
 		ajax::success($return);
@@ -213,7 +213,7 @@ try {
 
 	if (init('action') == 'setOrder') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$position = 1;
 		foreach (json_decode(init('objects'), true) as $id) {
@@ -229,7 +229,7 @@ try {
 
 	if (init('action') == 'getUISelectList') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(jeeObject::getUISelectList(init('none'), true));
 	}
@@ -258,7 +258,7 @@ try {
 		} else {
 			$object = jeeObject::byId(init('id'));
 			if (!is_object($object)) {
-				throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+				throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 			}
 			$info_object = array();
 			$info_object['id'] = $object->getId();
@@ -269,12 +269,12 @@ try {
 
 	if (init('action') == 'removeImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		$object->setImage('data', '');
 		$object->setImage('sha512', '');
@@ -292,23 +292,23 @@ try {
 
 	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$object = jeeObject::byId(init('id'));
 		if (!is_object($object)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (init('file') == '') {
 			if (!isset($_FILES['file'])) {
-				throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+				throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 			}
 			$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 			if (!in_array($extension, array('.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp'))) {
-				throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif .svg .webp) :', __FILE__) . ' ' . $extension);
+				throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png .gif .svg .webp) :', __FILE__) . ' ' . $extension);
 			}
 			if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-				throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+				throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 			}
 			$upfilepath = $_FILES['file']['tmp_name'];
 		} else {
@@ -328,13 +328,13 @@ try {
 		$filepath = __DIR__ . '/../../data/object/' . $filename;
 		file_put_contents($filepath, file_get_contents($upfilepath));
 		if (!file_exists($filepath)) {
-			throw new \Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new \Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 		$object->save();
 		ajax::success(array('filepath' => $filepath));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/plan.ajax.php
+++ b/core/ajax/plan.ajax.php
@@ -21,14 +21,14 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('uploadImagePlan', 'uploadImage'));
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plans = json_decode(init('plans'), true);
@@ -46,7 +46,7 @@ try {
 	if (init('action') == 'execute') {
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
-			throw new Exception(__('Aucun plan correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan correspondant', __FILE__));
 		}
 		ajax::success($plan->execute());
 	}
@@ -65,7 +65,7 @@ try {
 
 	if (init('action') == 'create') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan = new plan();
@@ -76,12 +76,12 @@ try {
 
 	if (init('action') == 'copy') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
-			throw new Exception(__('Aucun plan correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan correspondant', __FILE__));
 		}
 		ajax::success($plan->copy()->getHtml(init('version', 'dashboard')));
 	}
@@ -89,34 +89,34 @@ try {
 	if (init('action') == 'get') {
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
-			throw new Exception(__('Aucun plan correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan correspondant', __FILE__));
 		}
 		ajax::success($plan->getHtml('dashboard'));
 	}
 
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
-			throw new Exception(__('Aucun plan correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan correspondant', __FILE__));
 		}
 		ajax::success($plan->remove());
 	}
 
 	if (init('action') == 'removePlanHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!$planHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design', __FILE__));
 		}
 		$planHeader->remove();
 		ajax::success();
@@ -139,13 +139,13 @@ try {
 	if (init('action') == 'getPlanHeader') {
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
-			throw new Exception(__('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		if (!$planHeader->hasRight('r')) {
-			throw new Exception(__('Vous n\'avez pas le droit de voir ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de voir ce design', __FILE__));
 		}
 		if (trim($planHeader->getConfiguration('accessCode', '')) != '' && $planHeader->getConfiguration('accessCode', '') != sha512(init('code'))) {
-			throw new Exception(__('Code d\'accès invalide', __FILE__), -32005);
+			throw new Exception(new Trad('Code d\'accès invalide', __FILE__), -32005);
 		}
 		$return = utils::o2a($planHeader);
 		$return['image'] = $planHeader->displayImage();
@@ -154,7 +154,7 @@ try {
 
 	if (init('action') == 'savePlanHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$planHeader_ajax = json_decode(init('planHeader'), true);
@@ -166,7 +166,7 @@ try {
 			$planHeader = new planHeader();
 		}
 		if (!$planHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design', __FILE__));
 		}
 		utils::a2o($planHeader, $planHeader_ajax);
 		$planHeader->save();
@@ -175,30 +175,30 @@ try {
 
 	if (init('action') == 'copyPlanHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
-			throw new Exception(__('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		if (!$planHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design', __FILE__));
 		}
 		ajax::success(utils::o2a($planHeader->copy(init('name'))));
 	}
 
 	if (init('action') == 'removeImageHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
-			throw new Exception(__('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Plan header inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		if (!$planHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design', __FILE__));
 		}
 		$filename = 'planHeader' . $planHeader->getId() . '-' . $planHeader->getImage('sha512') . '.' . $planHeader->getImage('type');
 		$planHeader->setImage('sha512', '');
@@ -209,25 +209,25 @@ try {
 
 	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!$planHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design', __FILE__));
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.jpg', '.png', '.gif'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png .gif) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 		}
 		$files = ls(__DIR__ . '/../../data/plan/', 'planHeader' . $planHeader->getId() . '*');
 		if (count($files)  > 0) {
@@ -243,7 +243,7 @@ try {
 		$filepath = __DIR__ . '/../../data/plan/' . $filename;
 		file_put_contents($filepath, file_get_contents($_FILES['file']['tmp_name']));
 		if (!file_exists($filepath)) {
-			throw new \Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new \Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 		$planHeader->save();
 		ajax::success(array('filepath' => $filepath));
@@ -251,22 +251,22 @@ try {
 
 	if (init('action') == 'uploadImagePlan') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.jpg', '.png'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 		}
 		$uploaddir = __DIR__ . '/../../data/plan/plan_' . $plan->getId();
 		if (!file_exists($uploaddir)) {
@@ -277,7 +277,7 @@ try {
 		$filePath = $uploaddir . '/' . $fileName;
 		$img_size = getimagesize($_FILES['file']['tmp_name']);
 		if (!move_uploaded_file($_FILES['file']['tmp_name'], $filePath)) {
-			throw new Exception(__('Impossible de déplacer le fichier temporaire dans :', __FILE__) . ' ' . $uploaddir . '/' . $fileName);
+			throw new Exception(new Trad('Impossible de déplacer le fichier temporaire dans :', __FILE__) . ' ' . $uploaddir . '/' . $fileName);
 		}
 		$plan->setDisplay('width', $img_size[0]);
 		$plan->setDisplay('height', $img_size[1]);
@@ -286,7 +286,7 @@ try {
 		ajax::success(array('filepath' => $filePath));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/plan3d.ajax.php
+++ b/core/ajax/plan3d.ajax.php
@@ -21,14 +21,14 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('uploadModel'));
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3ds = json_decode(init('plan3ds'), true);
@@ -55,7 +55,7 @@ try {
 
 	if (init('action') == 'create') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3d = new plan3d();
@@ -67,7 +67,7 @@ try {
 	if (init('action') == 'get') {
 		$plan3d = plan3d::byId(init('id'));
 		if (!is_object($plan3d)) {
-			throw new Exception(__('Aucun plan3d correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan3d correspondant', __FILE__));
 		}
 		$return = jeedom::toHumanReadable(utils::o2a($plan3d));
 		$return['additionalData'] = $plan3d->additionalData();
@@ -84,27 +84,27 @@ try {
 
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3d = plan3d::byId(init('id'));
 		if (!is_object($plan3d)) {
-			throw new Exception(__('Aucun plan3d correspondant', __FILE__));
+			throw new Exception(new Trad('Aucun plan3d correspondant', __FILE__));
 		}
 		ajax::success($plan3d->remove());
 	}
 
 	if (init('action') == 'removeplan3dHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3dHeader = plan3dHeader::byId(init('id'));
 		if (!is_object($plan3dHeader)) {
-			throw new Exception(__('Objet inconnu vérifiez l\'id', __FILE__));
+			throw new Exception(new Trad('Objet inconnu vérifiez l\'id', __FILE__));
 		}
 		if (!$plan3dHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
 		}
 		$plan3dHeader->remove();
 		ajax::success();
@@ -124,13 +124,13 @@ try {
 	if (init('action') == 'getplan3dHeader') {
 		$plan3dHeader = plan3dHeader::byId(init('id'));
 		if (!is_object($plan3dHeader)) {
-			throw new Exception(__('plan3d header inconnu vérifiez l\'id :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('plan3d header inconnu vérifiez l\'id :', __FILE__) . ' ' . init('id'));
 		}
 		if (!$plan3dHeader->hasRight('r')) {
-			throw new Exception(__('Vous n\'avez pas le droit de voir ce design 3d', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de voir ce design 3d', __FILE__));
 		}
 		if (trim($plan3dHeader->getConfiguration('accessCode', '')) != '' && $plan3dHeader->getConfiguration('accessCode', '') != sha512(init('code'))) {
-			throw new Exception(__('Code d\'accès invalide', __FILE__), -32005);
+			throw new Exception(new Trad('Code d\'accès invalide', __FILE__), -32005);
 		}
 		$return = utils::o2a($plan3dHeader);
 		ajax::success($return);
@@ -138,7 +138,7 @@ try {
 
 	if (init('action') == 'saveplan3dHeader') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3dHeader_ajax = json_decode(init('plan3dHeader'), true);
@@ -150,7 +150,7 @@ try {
 			$plan3dHeader = new plan3dHeader();
 		}
 		if (!$plan3dHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
 		}
 		utils::a2o($plan3dHeader, $plan3dHeader_ajax);
 		$plan3dHeader->save();
@@ -159,32 +159,32 @@ try {
 
 	if (init('action') == 'uploadModel') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plan3dHeader = plan3dHeader::byId(init('id'));
 		if (!is_object($plan3dHeader)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!$plan3dHeader->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier ce design 3d', __FILE__));
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.zip'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .zip) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .zip) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 150000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 150Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 150Mo)', __FILE__));
 		}
 		$uploaddir = '/tmp';
 		if (!move_uploaded_file($_FILES['file']['tmp_name'], $uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de déplacer le fichier temporaire', __FILE__));
+			throw new Exception(new Trad('Impossible de déplacer le fichier temporaire', __FILE__));
 		}
 		if (!file_exists($uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
+			throw new Exception(new Trad('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
 		if ($plan3dHeader->getConfiguration('path') == '') {
 			$plan3dHeader->setConfiguration('path', 'data/3d/' . config::genKey() . '/');
@@ -195,16 +195,16 @@ try {
 		$res = $zip->open($file);
 		if ($res === TRUE) {
 			if (!$zip->extractTo($cibDir . '/')) {
-				throw new Exception(__('Impossible de décompresser les fichiers :', __FILE__) . ' ');
+				throw new Exception(new Trad('Impossible de décompresser les fichiers :', __FILE__) . ' ');
 			}
 			$zip->close();
 			unlink($file);
 		} else {
-			throw new Exception(__('Impossible de décompresser l\'archive zip :', __FILE__) . ' ' . $file . ' => ' . ZipErrorMessage($res));
+			throw new Exception(new Trad('Impossible de décompresser l\'archive zip :', __FILE__) . ' ' . $file . ' => ' . ZipErrorMessage($res));
 		}
 		$objfile = ls($cibDir, '*.obj', false, array('files'));
 		if (count($objfile) != 1) {
-			throw new Exception(__('Il faut un seul et unique fichier .obj', __FILE__));
+			throw new Exception(new Trad('Il faut un seul et unique fichier .obj', __FILE__));
 		}
 		$plan3dHeader->setConfiguration('objfile', $objfile[0]);
 		$mtlfile = ls($cibDir, '*.mtl', false, array('files'));
@@ -215,7 +215,7 @@ try {
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondant à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondant à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -21,14 +21,14 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
 
 	if (init('action') == 'getConf') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$plugin = plugin::byId(init('id'),init('full',0));
 		$update = update::byLogicalId(init('id'));
@@ -45,11 +45,11 @@ try {
 	if (init('action') == 'toggle') {
 		unautorizedInDemo();
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
-			throw new Exception(__('Plugin introuvable :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Plugin introuvable :', __FILE__) . ' ' . init('id'));
 		}
 		$plugin->setIsEnable(init('state'));
 		ajax::success();
@@ -57,14 +57,14 @@ try {
 
 	if (init('action') == 'all') {
 		if (!isConnect()) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(utils::o2a(plugin::listPlugin(init('activateOnly', false))));
 	}
 
 	if (init('action') == 'getDependancyInfo') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 
 		$return = array('state' => 'nok', 'log' => 'nok');
@@ -77,7 +77,7 @@ try {
 
 	if (init('action') == 'dependancyInstall') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
@@ -89,7 +89,7 @@ try {
 
 	if (init('action') == 'dependancyChangeAutoMode') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
@@ -101,7 +101,7 @@ try {
 
 	if (init('action') == 'getDeamonInfo') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$plugin_id = init('id');
 		$return = array('launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0);
@@ -115,7 +115,7 @@ try {
 
 	if (init('action') == 'deamonStart') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plugin_id = init('id');
@@ -128,7 +128,7 @@ try {
 
 	if (init('action') == 'deamonStop') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
@@ -140,7 +140,7 @@ try {
 
 	if (init('action') == 'deamonChangeAutoMode') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
@@ -151,9 +151,9 @@ try {
 	}
 
 	if (init('action') == 'createCommunityPost') {
-		$header = __('Remplacez ce texte par votre demande en prenant soin de ne pas effacer les informations renseignées ci-dessous.', __FILE__) . '<br><br><br><br>';
+		$header = new Trad('Remplacez ce texte par votre demande en prenant soin de ne pas effacer les informations renseignées ci-dessous.', __FILE__) . '<br><br><br><br>';
 		$header .= '<br>---<br>';
-		$header .= '**' . __('Informations', __FILE__) . ' ' . config::byKey('product_name') . '**';
+		$header .= '**' . new Trad('Informations', __FILE__) . ' ' . config::byKey('product_name') . '**';
 		$header .= '<br>```<br>';
 		$footer = '<br>```<br>';
 
@@ -172,17 +172,17 @@ try {
 			$isBeta = ($version && $version != 'stable');
 		}
 
-		$infoPost .= __('Version', __FILE__) . ' : ' . $update->getLocalVersion() . ' (' . ($isBeta ? 'beta' : 'stable') . ')';
+		$infoPost .= new Trad('Version', __FILE__) . ' : ' . $update->getLocalVersion() . ' (' . ($isBeta ? 'beta' : 'stable') . ')';
 
 		if ($plugin->getHasOwnDeamon()) {
 			$daemon_info = $plugin->deamon_info();
-			$infoPost .= '<br>' . __('Statut Démon', __FILE__) . ' : ' . ($daemon_info['state'] == 'ok' ?  __('Démarré', __FILE__) :  __('Stoppé', __FILE__));
-			$infoPost .= ' - (' . ($daemon_info['last_launch'] ?? __('Inconnue', __FILE__)) . ')';
+			$infoPost .= '<br>' . new Trad('Statut Démon', __FILE__) . ' : ' . ($daemon_info['state'] == 'ok' ?  new Trad('Démarré', __FILE__) :  new Trad('Stoppé', __FILE__));
+			$infoPost .= ' - (' . ($daemon_info['last_launch'] ?? new Trad('Inconnue', __FILE__)) . ')';
 		}
 
 		$infoPlugin = '';
 		if (method_exists($plugin_id, 'getConfigForCommunity')) {
-			$infoPlugin .= '**' . __('Informations complémentaires', __FILE__) .  '**<br>';
+			$infoPlugin .= '**' . new Trad('Informations complémentaires', __FILE__) .  '**<br>';
 			$infoPlugin .= $plugin_id::getConfigForCommunity();
 		}
 
@@ -203,7 +203,7 @@ try {
 		ajax::success(array('url' => $url, 'plugin' => $plugin->getName()));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/queue.ajax.php
+++ b/core/ajax/queue.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -36,7 +36,7 @@ try {
 		unautorizedInDemo();
 		$queue = queue::byId(init('id'));
 		if (!is_object($queue)) {
-			throw new Exception(__('Queue id inconnu', __FILE__));
+			throw new Exception(new Trad('Queue id inconnu', __FILE__));
 		}
 		$queue->remove();
 		ajax::success();
@@ -53,7 +53,7 @@ try {
 	if (init('action') == 'start') {
 		$queue = queue::byId(init('id'));
 		if (!is_object($queue)) {
-			throw new Exception(__('Queue id inconnu', __FILE__));
+			throw new Exception(new Trad('Queue id inconnu', __FILE__));
 		}
 		$queue->run();
 		sleep(1);
@@ -63,14 +63,14 @@ try {
 	if (init('action') == 'stop') {
 		$queue = queue::byId(init('id'));
 		if (!is_object($queue)) {
-			throw new Exception(__('Queue id inconnu', __FILE__));
+			throw new Exception(new Trad('Queue id inconnu', __FILE__));
 		}
 		$queue->halt();
 		sleep(1);
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/ajax/recovery.ajax.php
+++ b/core/ajax/recovery.ajax.php
@@ -22,7 +22,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init();
@@ -44,7 +44,7 @@ try {
 		ajax::success(recovery::usbConnected(init('hardware')));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init();
@@ -56,14 +56,14 @@ try {
 		$class = 'repo_' . init('repo');
 		$repo = $class::byId(init('id'));
 		if (!is_object($repo)) {
-			throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
 		}
 		$update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
 		if (!is_object($update)) {
 			$update = new update();
 		}
 		if ($update->getConfiguration('doNotUpdate') == 1) {
-			throw new Exception(__('Mise à jour et réinstallation désactivées sur ', __FILE__) . ' ' . $repo->getLogicalId());
+			throw new Exception(new Trad('Mise à jour et réinstallation désactivées sur ', __FILE__) . ' ' . $repo->getLogicalId());
 		}		
 		$update->setSource(init('repo'));
 		$update->setLogicalId($repo->getLogicalId());
@@ -86,7 +86,7 @@ try {
 		$class = 'repo_' . init('repo');
 		$repo = $class::byId(init('id'));
 		if (!is_object($market)) {
-			throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
 		}
 		$update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
 		try {
@@ -140,7 +140,7 @@ try {
 		$class = 'repo_' . init('repo');
 		$repo = $class::byId(init('id'));
 		if (!is_object($repo)) {
-			throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
 		}
 		$repo->setRating(init('rating'));
 		ajax::success();
@@ -151,7 +151,7 @@ try {
 		ajax::success($class::backup_list());
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/ajax/report.ajax.php
+++ b/core/ajax/report.ajax.php
@@ -22,7 +22,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init();
@@ -51,7 +51,7 @@ try {
 			unlink($path);
 		}
 		if (file_exists($path)) {
-			throw new Exception(__('Impossible de supprimer :', __FILE__) . ' ' . $path);
+			throw new Exception(new Trad('Impossible de supprimer :', __FILE__) . ' ' . $path);
 		}
 		ajax::success();
 	}
@@ -64,7 +64,7 @@ try {
 		ajax::success($return);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/scenario.ajax.php
+++ b/core/ajax/scenario.ajax.php
@@ -161,7 +161,7 @@ try {
 						$return[$match[0]] = '';
 						try {
 							$eqLogic = eqLogic::byString($match[0]);
-							if (is_object($cmd)) {
+							if (is_object($eqLogic)) {
 								$return[$match[0]] = '#' . $eqLogic->getHumanName() . '#';
 							}
 						} catch (Exception $e) {

--- a/core/ajax/scenario.ajax.php
+++ b/core/ajax/scenario.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('templateupload'));
@@ -29,15 +29,15 @@ try {
 	if (init('action') == 'changeState') {
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
 		}
 		if (!$scenario->hasRight('x')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		switch (init('state')) {
 			case 'start':
 				if (!$scenario->getIsActive()) {
-					throw new Exception(__('Impossible de lancer le scénario car il est désactivé. Veuillez l\'activer', __FILE__));
+					throw new Exception(new Trad('Impossible de lancer le scénario car il est désactivé. Veuillez l\'activer', __FILE__));
 				}
 				$scenario->addTag('trigger','user');
 				$scenario->addTag('trigger_value',$_SESSION['user']->getLogin());
@@ -106,19 +106,19 @@ try {
 	if (init('action') == 'convertToTemplate') {
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
 		}
 		$path = __DIR__ . '/../../data/scenario';
 		if (!file_exists($path)) {
 			mkdir($path);
 		}
 		if (trim(init('template')) == '' || trim(init('template')) == '.json') {
-			throw new Exception(__('Le nom du template ne peut être vide', __FILE__) . ' ');
+			throw new Exception(new Trad('Le nom du template ne peut être vide', __FILE__) . ' ');
 		}
 		$name = init('template');
 		file_put_contents($path . '/' . $name, json_encode($scenario->export('array'), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 		if (!file_exists($path . '/' . $name)) {
-			throw new Exception(__('Impossible de créer le template, vérifiez les droits :', __FILE__) . ' ' . $path . '/' . $name);
+			throw new Exception(new Trad('Impossible de créer le template, vérifiez les droits :', __FILE__) . ' ' . $path . '/' . $name);
 		}
 		ajax::success();
 	}
@@ -135,7 +135,7 @@ try {
 	if (init('action') == 'loadTemplateDiff') {
 		$path = __DIR__ . '/../../data/scenario';
 		if (!file_exists($path . '/' . init('template'))) {
-			throw new Exception(__('Fichier non trouvé :', __FILE__) . ' ' . $path . '/' . init('template'));
+			throw new Exception(new Trad('Fichier non trouvé :', __FILE__) . ' ' . $path . '/' . init('template'));
 		}
 		$return = array();
 		$fileContent = file_get_contents($path . '/' . init('template'));
@@ -184,11 +184,11 @@ try {
 		unautorizedInDemo();
 		$path = __DIR__ . '/../../data/scenario';
 		if (!file_exists($path . '/' . init('template'))) {
-			throw new Exception(__('Fichier non trouvé :', __FILE__) . ' ' . $path . '/' . init('template'));
+			throw new Exception(new Trad('Fichier non trouvé :', __FILE__) . ' ' . $path . '/' . init('template'));
 		}
 		foreach (json_decode(init('convert'), true) as $value) {
 			if (trim($value['end']) == '') {
-				throw new Exception(__('La conversion suivante ne peut être vide :', __FILE__) . ' ' . $value['begin']);
+				throw new Exception(new Trad('La conversion suivante ne peut être vide :', __FILE__) . ' ' . $value['begin']);
 			}
 			$converts[$value['begin']] = $value['end'];
 		}
@@ -203,10 +203,10 @@ try {
 		}
 		$scenario_db = scenario::byId(init('id'));
 		if (!is_object($scenario_db)) {
-			throw new Exception(__('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Scénario ID inconnu :', __FILE__) . ' ' . init('id'));
 		}
 		if (!$scenario_db->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$scenario_db->setTrigger(array());
 		$scenario_db->setSchedule(array());
@@ -237,7 +237,7 @@ try {
 	if (init('action') == 'byId') {
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu', __FILE__));
+			throw new Exception(new Trad('Scénario ID inconnu', __FILE__));
 		}
 		ajax::success(utils::o2a($scenario));
 	}
@@ -284,7 +284,7 @@ try {
 
 	if (init('action') == 'autoCompleteGroup') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$return = array();
 		foreach (scenario::listGroup(init('term')) as $group) {
@@ -320,15 +320,15 @@ try {
 
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu', __FILE__));
+			throw new Exception(new Trad('Scénario ID inconnu', __FILE__));
 		}
 		if (!$scenario->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$scenario->remove();
 		ajax::success();
@@ -336,7 +336,7 @@ try {
 
 	if (init('action') == 'clearAllLogs') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$scenarios = scenario::all();
 		foreach ($scenarios as $scenario) {
@@ -349,11 +349,11 @@ try {
 
 	if (init('action') == 'emptyLog') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu', __FILE__));
+			throw new Exception(new Trad('Scénario ID inconnu', __FILE__));
 		}
 		if (file_exists(__DIR__ . '/../../log/scenarioLog/scenario' . $scenario->getId() . '.log')) {
 			unlink(__DIR__ . '/../../log/scenarioLog/scenario' . $scenario->getId() . '.log');
@@ -363,12 +363,12 @@ try {
 
 	if (init('action') == 'copy') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu', __FILE__));
+			throw new Exception(new Trad('Scénario ID inconnu', __FILE__));
 		}
 		ajax::success(utils::o2a($scenario->copy(init('name'))));
 	}
@@ -376,7 +376,7 @@ try {
 	if (init('action') == 'get') {
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario ID inconnu', __FILE__));
+			throw new Exception(new Trad('Scénario ID inconnu', __FILE__));
 		}
 		$return = utils::o2a($scenario);
 		$return['trigger'] = jeedom::toHumanReadable($return['trigger']);
@@ -456,10 +456,10 @@ try {
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		if (!is_json(init('scenario'))) {
-			throw new Exception(__('Champs json invalide', __FILE__));
+			throw new Exception(new Trad('Champs json invalide', __FILE__));
 		}
 		unautorizedInDemo();
 		$time_dependance = 0;
@@ -485,7 +485,7 @@ try {
 		if (!isset($scenario_db) || !is_object($scenario_db)) {
 			$scenario_db = new scenario();
 		} elseif (!$scenario_db->hasRight('w')) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		if (isset($scenario_ajax['trigger'])) {
 			$scenario_db->setTrigger(array());
@@ -536,28 +536,28 @@ try {
 			mkdir($uploaddir);
 		}
 		if (!file_exists($uploaddir)) {
-			throw new Exception(__('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
+			throw new Exception(new Trad('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.json'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .json) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .json) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 10000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 10Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 10Mo)', __FILE__));
 		}
 		if (!move_uploaded_file($_FILES['file']['tmp_name'], $uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de déplacer le fichier temporaire', __FILE__));
+			throw new Exception(new Trad('Impossible de déplacer le fichier temporaire', __FILE__));
 		}
 		if (!file_exists($uploaddir . '/' . $_FILES['file']['name'])) {
-			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
+			throw new Exception(new Trad('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/timeline.ajax.php
+++ b/core/ajax/timeline.ajax.php
@@ -21,7 +21,7 @@ try {
   include_file('core', 'authentification', 'php');
   
   if (!isConnect()) {
-    throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+    throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
   }
   
   ajax::init();
@@ -61,7 +61,7 @@ try {
     ajax::success(timeline::removeEventInFutur());
   }
   
-  throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+  throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
   /*     * *********Catch exeption*************** */
 } catch (Exception $e) {
   ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -21,7 +21,7 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init(array('preUploadFile'));
@@ -31,7 +31,7 @@ try {
 	}
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	if (init('action') == 'all') {
@@ -73,15 +73,15 @@ try {
 		log::clear('update');
 		$update = update::byId(init('id'));
 		if (!is_object($update)) {
-			throw new Exception(__('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		try {
 			if ($update->getType() != 'core') {
-				log::add('update', 'alert', __("[START UPDATE]", __FILE__));
+				log::add('update', 'alert', new Trad("[START UPDATE]", __FILE__));
 			}
 			$update->doUpdate();
 			if ($update->getType() != 'core') {
-				log::add('update', 'alert', __("Launch cron dependancy plugins", __FILE__));
+				log::add('update', 'alert', new Trad("Launch cron dependancy plugins", __FILE__));
 				try {
 					$cron = cron::byClassAndFunction('plugin', 'checkDeamon');
 					if (is_object($cron)) {
@@ -89,12 +89,12 @@ try {
 					}
 				} catch (Exception $e) {
 				}
-				log::add('update', 'alert', __("[END UPDATE SUCCESS]", __FILE__));
+				log::add('update', 'alert', new Trad("[END UPDATE SUCCESS]", __FILE__));
 			}
 		} catch (Exception $e) {
 			if ($update->getType() != 'core') {
 				log::add('update', 'alert', $e->getMessage());
-				log::add('update', 'alert', __("[END UPDATE ERROR]", __FILE__));
+				log::add('update', 'alert', new Trad("[END UPDATE ERROR]", __FILE__));
 			}
 		}
 		ajax::success();
@@ -108,7 +108,7 @@ try {
 			$update = update::byLogicalId(init('id'));
 		}
 		if (!is_object($update)) {
-			throw new Exception(__('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		$update->deleteObjet();
 		ajax::success();
@@ -121,7 +121,7 @@ try {
 			$update = update::byLogicalId(init('id'));
 		}
 		if (!is_object($update)) {
-			throw new Exception(__('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		$update->checkUpdate();
 		ajax::success();
@@ -173,25 +173,25 @@ try {
 		unautorizedInDemo();
 		$uploaddir = '/tmp';
 		if (!file_exists($uploaddir)) {
-			throw new Exception(__('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
+			throw new Exception(new Trad('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . $uploaddir);
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 100000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 100Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 100Mo)', __FILE__));
 		}
 		$filename = str_replace(array(' ', '(', ')'), '', $_FILES['file']['name']);
 		if (!move_uploaded_file($_FILES['file']['tmp_name'], $uploaddir . '/' . $filename)) {
-			throw new Exception(__('Impossible de déplacer le fichier temporaire', __FILE__));
+			throw new Exception(new Trad('Impossible de déplacer le fichier temporaire', __FILE__));
 		}
 		if (!file_exists($uploaddir . '/' . $filename)) {
-			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
+			throw new Exception(new Trad('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
 		ajax::success($uploaddir . '/' . $filename);
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -44,15 +44,15 @@ try {
 					@session_start();
 					$_SESSION['user'] = $user;
 					@session_write_close();
-					log::add('connection', 'info', __('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $_SESSION['user']->getLogin());
+					log::add('connection', 'info', new Trad('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $_SESSION['user']->getLogin());
 				}
 			}
 			$user = user::connect(init('username'), init('password'));
 			if (is_object($user) && network::getUserLocation() != 'internal' && $user->getOptions('twoFactorAuthentification', 0) == 1 && $user->getOptions('twoFactorAuthentificationSecret') != '' && init('twoFactorCode') == '') {
-				throw new Exception(__('Double authentification requise', __FILE__), -32012);
+				throw new Exception(new Trad('Double authentification requise', __FILE__), -32012);
 			}
 			if (!login(init('username'), init('password'), init('twoFactorCode'))) {
-				throw new Exception(__('Mot de passe ou nom d\'utilisateur incorrect', __FILE__));
+				throw new Exception(new Trad('Mot de passe ou nom d\'utilisateur incorrect', __FILE__));
 			}
 		}
 
@@ -83,13 +83,13 @@ try {
 
 	if (init('action') == 'getApikey') {
 		if (!login(init('username'), init('password'), init('twoFactorCode'))) {
-			throw new Exception(__('Mot de passe ou nom d\'utilisateur incorrect', __FILE__));
+			throw new Exception(new Trad('Mot de passe ou nom d\'utilisateur incorrect', __FILE__));
 		}
 		ajax::success($_SESSION['user']->getHash());
 	}
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	ajax::init();
@@ -109,7 +109,7 @@ try {
 
 	if (init('action') == 'removeTwoFactorCode') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$user = user::byId(init('id'));
@@ -139,7 +139,7 @@ try {
 
 	if (init('action') == 'all') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$users = array();
@@ -152,7 +152,7 @@ try {
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$users = jeedom::fromHumanReadable(json_decode(init('users'), true));
@@ -163,7 +163,7 @@ try {
 			}
 			if (!is_object($user)) {
 				if (config::byKey('ldap::enable') == '1') {
-					throw new Exception(__('Vous devez désactiver l\'authentification LDAP pour pouvoir ajouter un utilisateur', __FILE__));
+					throw new Exception(new Trad('Vous devez désactiver l\'authentification LDAP pour pouvoir ajouter un utilisateur', __FILE__));
 				}
 				$user = new user();
 			}
@@ -186,12 +186,12 @@ try {
 
 	if (init('action') == 'copyRights') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$from = user::byId(init('from'));
 		$to = user::byId(init('to'));
 		if (!is_object($from) || !is_object($to)) {
-			throw new Exception(__('Utilisateur invalide', __FILE__));
+			throw new Exception(new Trad('Utilisateur invalide', __FILE__));
 		}
 		$rights = $from->getRights();
 		foreach ($rights as $key => $value) {
@@ -203,18 +203,18 @@ try {
 
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		if (config::byKey('ldap::enable') == '1') {
-			throw new Exception(__('Vous devez désactiver l\'authentification LDAP pour pouvoir supprimer un utilisateur', __FILE__));
+			throw new Exception(new Trad('Vous devez désactiver l\'authentification LDAP pour pouvoir supprimer un utilisateur', __FILE__));
 		}
 		if (init('id') == $_SESSION['user']->getId()) {
-			throw new Exception(__('Vous ne pouvez pas supprimer le compte avec lequel vous êtes connecté', __FILE__));
+			throw new Exception(new Trad('Vous ne pouvez pas supprimer le compte avec lequel vous êtes connecté', __FILE__));
 		}
 		$user = user::byId(init('id'));
 		if (!is_object($user)) {
-			throw new Exception(__('User ID inconnu', __FILE__));
+			throw new Exception(new Trad('User ID inconnu', __FILE__));
 		}
 		$user->remove();
 		ajax::success();
@@ -224,7 +224,7 @@ try {
 		unautorizedInDemo();
 		$user_json = jeedom::fromHumanReadable(json_decode(init('profils'), true));
 		if (isset($user_json['id']) && $user_json['id'] != $_SESSION['user']->getId()) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		@session_start();
 		$_SESSION['user']->refresh();
@@ -243,11 +243,11 @@ try {
 	if (init('action') == 'get') {
 		if (init('id') > 0) {
 			if (!isConnect('admin')) {
-				throw new Exception(__('401 - Accès non autorisé', __FILE__));
+				throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 			}
 			$user = user::byId(init('id'));
 			if (!is_object($user)) {
-				throw new Exception(__('Utilisateur non trouvé :', __FILE__) . ' ' . init('id'));
+				throw new Exception(new Trad('Utilisateur non trouvé :', __FILE__) . ' ' . init('id'));
 			}
 			ajax::success(jeedom::toHumanReadable(utils::o2a($user)));
 		}
@@ -258,7 +258,7 @@ try {
 		unautorizedInDemo();
 		if (init('key') == '' && init('user_id') == '') {
 			if (!isConnect('admin')) {
-				throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+				throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 			}
 			foreach ((user::all()) as $user) {
 				if ($user->getId() == $_SESSION['user']->getId()) {
@@ -276,11 +276,11 @@ try {
 		}
 		if (init('user_id') != '') {
 			if (!isConnect('admin')) {
-				throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+				throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 			}
 			$user = user::byId(init('user_id'));
 			if (!is_object($user)) {
-				throw new Exception(__('Utilisateur non trouvé :', __FILE__) . ' ' . init('user_id'));
+				throw new Exception(new Trad('Utilisateur non trouvé :', __FILE__) . ' ' . init('user_id'));
 			}
 			$registerDevice = $user->getOptions('registerDevice', array());
 		} else {
@@ -326,12 +326,12 @@ try {
 	}
 
 	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
 	}
 
 	if (init('action') == 'testLdapConnection') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$connection = user::connectToLDAP();
@@ -351,7 +351,7 @@ try {
 		ajax::success(user::supportAccess(init('enable')));
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -21,37 +21,37 @@ try {
 	include_file('core', 'authentification', 'php');
 
 	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	ajax::init(array('uploadImage'));
 
 	if (init('action') == 'copy') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
-			throw new Exception(__('Vue non trouvée. Vérifiez l\'iD', __FILE__));
+			throw new Exception(new Trad('Vue non trouvée. Vérifiez l\'iD', __FILE__));
 		}
 		if (!$view->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
 		}
 		ajax::success(utils::o2a($view->copy(init('name'))));
 	}
 
 	if (init('action') == 'remove') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
-			throw new Exception(__('Vue non trouvée. Vérifiez l\'iD', __FILE__));
+			throw new Exception(new Trad('Vue non trouvée. Vérifiez l\'iD', __FILE__));
 		}
 		if (!$view->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
 		}
 		$view->remove();
 		ajax::success();
@@ -91,10 +91,10 @@ try {
 		} else {
 			$view = view::byId(init('id'));
 			if (!is_object($view)) {
-				throw new Exception(__('Vue non trouvée. Vérifiez l\'ID', __FILE__));
+				throw new Exception(new Trad('Vue non trouvée. Vérifiez l\'ID', __FILE__));
 			}
 			if (!$view->hasRight('r')) {
-				throw new Exception(__('Vous n\'avez pas le droit de voir cette vue', __FILE__));
+				throw new Exception(new Trad('Vous n\'avez pas le droit de voir cette vue', __FILE__));
 			}
 			ajax::success($view->toAjax(init('version', 'dashboard'), init('html')));
 		}
@@ -102,7 +102,7 @@ try {
 
 	if (init('action') == 'save') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$view = view::byId(init('view_id'));
@@ -110,11 +110,11 @@ try {
 			$view = new view();
 		}
 		if (!$view->hasRight('w')) {
-			throw new Exception(__('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
+			throw new Exception(new Trad('Vous n\'avez pas le droit de modifier cette vue', __FILE__));
 		}
 		$view_ajax = json_decode(init('view'), true);
 		if (!is_array($view_ajax) || count($view_ajax) == 0) {
-			throw new Exception(__('Erreur dans le decodage json veuiller réessaye : ', __FILE__) . init('view'));
+			throw new Exception(new Trad('Erreur dans le decodage json veuiller réessaye : ', __FILE__) . init('view'));
 		}
 		utils::a2o($view, $view_ajax);
 		$view->save();
@@ -146,7 +146,7 @@ try {
 	if (init('action') == 'getEqLogicviewZone') {
 		$viewZone = viewZone::byId(init('viewZone_id'));
 		if (!is_object($viewZone)) {
-			throw new Exception(__('Vue non trouvée. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Vue non trouvée. Vérifiez l\'ID', __FILE__));
 		}
 		$return = utils::o2a($viewZone);
 		$return['eqLogic'] = array();
@@ -160,7 +160,7 @@ try {
 
 	if (init('action') == 'setComponentOrder') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$components = json_decode(init('components'), true);
@@ -196,7 +196,7 @@ try {
 
 	if (init('action') == 'setOrder') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$order = 1;
@@ -213,12 +213,12 @@ try {
 
 	if (init('action') == 'removeImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
-			throw new Exception(__('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Vue inconnu. Vérifiez l\'ID', __FILE__) . ' ' . init('id'));
 		}
 		$view->setImage('sha512', '');
 		$view->save();
@@ -228,22 +228,22 @@ try {
 
 	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
-			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
+			throw new Exception(new Trad('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		if (!isset($_FILES['file'])) {
-			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
+			throw new Exception(new Trad('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 		if (!in_array($extension, array('.jpg', '.png'))) {
-			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
+			throw new Exception(new Trad('Extension du fichier non valide (autorisé .jpg .png) :', __FILE__) . ' ' . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {
-			throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));
+			throw new Exception(new Trad('Le fichier est trop gros (maximum 5Mo)', __FILE__));
 		}
 		$files = ls(__DIR__ . '/../../data/view/', 'view' . $view->getId() . '*');
 		if (count($files)  > 0) {
@@ -257,13 +257,13 @@ try {
 		$filepath = __DIR__ . '/../../data/view/' . $filename;
 		file_put_contents($filepath, file_get_contents($_FILES['file']['tmp_name']));
 		if (!file_exists($filepath)) {
-			throw new \Exception(__('Impossible de sauvegarder l\'image', __FILE__));
+			throw new \Exception(new Trad('Impossible de sauvegarder l\'image', __FILE__));
 		}
 		$view->save();
 		ajax::success();
 	}
 
-	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+	throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
 	ajax::error(displayException($e), $e->getCode());

--- a/core/ajax/widgets.ajax.php
+++ b/core/ajax/widgets.ajax.php
@@ -22,7 +22,7 @@ try {
   include_file('core', 'authentification', 'php');
   
   if (!isConnect('admin')) {
-    throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
+    throw new Exception(new Trad('401 - Accès non autorisé', __FILE__), -1234);
   }
   
   ajax::init();
@@ -47,7 +47,7 @@ try {
   if (init('action') == 'remove') {
     $widgets = widgets::byId(init('id'));
     if(!is_object($widgets)){
-      throw new Exception(__('Widgets inconnus - Vérifiez l\'id', __FILE__).init('id'));
+      throw new Exception(new Trad('Widgets inconnus - Vérifiez l\'id', __FILE__).init('id'));
     }
     $widgets->remove();
     ajax::success();
@@ -76,7 +76,7 @@ try {
     $widget = widgets::byId(init('id'));
     $usedBy = $widget->getUsedBy();
     if(!is_array($usedBy) || count($usedBy) == 0){
-      ajax::success(array('html' => '<div class="alert alert-warning">'.__('Aucune commande affectée au widget, prévisualisation impossible',__FILE__).'</div>'));
+      ajax::success(array('html' => '<div class="alert alert-warning">'.new Trad('Aucune commande affectée au widget, prévisualisation impossible',__FILE__).'</div>'));
     }
     ajax::success(array('html' =>$usedBy[0]->getEqLogic()->toHtml('dashboard')));
   }
@@ -85,7 +85,7 @@ try {
     ajax::success(widgets::replacement(init('version'),init('replace'),init('by')));
   }
   
-  throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
+  throw new Exception(new Trad('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
   
   /*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -1009,7 +1009,6 @@ try {
 			$params['log'],
 			$params['position'],
 			$params['search'],
-			$params['position'],
 			$params['colored'],
 			$params['numbered'],
 			$params['numStart'],

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -40,46 +40,46 @@ if (init('type') != '') {
 		
 		if (init('type') == 'ask') {
 			if (trim(init('token')) == '' || strlen(init('token')) < 64) {
-				throw new Exception(__('Commande inconnue ou Token invalide', __FILE__));
+				throw new Exception(new Trad('Commande inconnue ou Token invalide', __FILE__));
 			}
 			$cmd = cmd::byId(init('cmd_id'));
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande inconnue ou Token invalide', __FILE__));
+				throw new Exception(new Trad('Commande inconnue ou Token invalide', __FILE__));
 			}
 			if (trim($cmd->getCache('ask::token', config::genKey())) != init('token')) {
-				throw new Exception(__('Commande inconnue ou Token invalide', __FILE__));
+				throw new Exception(new Trad('Commande inconnue ou Token invalide', __FILE__));
 			}
 			if (!$cmd->askResponse(init('response'))) {
-				throw new Exception(__('Erreur response ask, temps écoulé ou réponse invalide', __FILE__));
+				throw new Exception(new Trad('Erreur response ask, temps écoulé ou réponse invalide', __FILE__));
 			}
 			die();
 		}
 		$plugin = init('plugin', 'core');
 		if (in_array($plugin, array('apitts', 'apipro', 'apimarket'))) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
 		}
 		if (!jeedom::apiAccess(init('apikey', init('api')), $plugin)) {
 			user::failedLogin();
 			sleep(5);
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 		}
 
 		if(config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), init('type'))){
-			throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
+			throw new Exception(new Trad('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 		}
 		if(config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), init('type'))){
-			throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
+			throw new Exception(new Trad('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 		}
 		$type = init('type');
-		log::add('api', 'debug', __('Demande sur l\'api http venant de :', __FILE__) . ' ' . getClientIp() . ' => ' . json_encode($_GET));
+		log::add('api', 'debug', new Trad('Demande sur l\'api http venant de :', __FILE__) . ' ' . getClientIp() . ' => ' . json_encode($_GET));
 
 		if ($type == 'event' && class_exists($plugin) && method_exists($plugin, 'event')) {
-			log::add('api', 'info', __('Appels de', __FILE__) . ' ' . secureXSS($plugin) . '::event()');
+			log::add('api', 'info', new Trad('Appels de', __FILE__) . ' ' . secureXSS($plugin) . '::event()');
 			$plugin::event();
 			die();
 		}
 		if ($_RESTRICTED) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__));
 		}
 		if ($type == 'cmd') {
 			if (is_json(init('id'))) {
@@ -88,10 +88,10 @@ if (init('type') != '') {
 				foreach ($ids as $id) {
 					$cmd = cmd::byId($id);
 					if (!is_object($cmd)) {
-						throw new Exception(__('Aucune commande correspondant à l\'ID :', __FILE__) . ' ' . secureXSS($id));
+						throw new Exception(new Trad('Aucune commande correspondant à l\'ID :', __FILE__) . ' ' . secureXSS($id));
 					}
 					if ($plugin != 'core' && $plugin != $cmd->getEqType() && $_RESTRICTED) {
-						throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
+						throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 					}
 					if ($_USER_GLOBAL != null && !$cmd->hasRight($_USER_GLOBAL)) {
 						continue;
@@ -103,18 +103,18 @@ if (init('type') != '') {
 			} else {
 				$cmd = cmd::byId(init('id'));
 				if (!is_object($cmd)) {
-					throw new Exception(__('Aucune commande correspondant à l\'ID :', __FILE__) . ' ' . secureXSS(init('id')));
+					throw new Exception(new Trad('Aucune commande correspondant à l\'ID :', __FILE__) . ' ' . secureXSS(init('id')));
 				}
 				if ($plugin != 'core' && $plugin != $cmd->getEqType() && $_RESTRICTED) {
-					throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
+					throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 				}
 				if ($_USER_GLOBAL != null && !$cmd->hasRight($_USER_GLOBAL)) {
-					throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
+					throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 				}
 				if ($cmd->getType() == 'info' && init('value') != '') {
 					$cmd->event(init('value'));
 				}
-				log::add('api', 'debug', __('Exécution de :', __FILE__) . ' ' . $cmd->getHumanName());
+				log::add('api', 'debug', new Trad('Exécution de :', __FILE__) . ' ' . $cmd->getHumanName());
 				echo $cmd->execCmd($_REQUEST);
 				die();
 			}
@@ -143,7 +143,7 @@ if (init('type') != '') {
 			die();
 		}
 		if ($type == 'scenario') {
-			log::add('api', 'debug', __('Demande API pour les scénarios', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les scénarios', __FILE__));
 			if (!init('id')) {
 				header('Content-Type: application/json');
 				echo json_encode(utils::o2a(scenario::all()), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
@@ -151,15 +151,15 @@ if (init('type') != '') {
 			}
 			$scenario = scenario::byId(init('id'));
 			if (!is_object($scenario)) {
-				throw new Exception(__('Aucun scénario correspondant à l\'ID :', __FILE__) . ' ' . secureXSS(init('id')));
+				throw new Exception(new Trad('Aucun scénario correspondant à l\'ID :', __FILE__) . ' ' . secureXSS(init('id')));
 			}
 			if ($_USER_GLOBAL != null && !$scenario->hasRight('x', $_USER_GLOBAL)) {
-				throw new Exception(__('Vous n\'avez pas le droit de faire une action sur ce scénario', __FILE__));
+				throw new Exception(new Trad('Vous n\'avez pas le droit de faire une action sur ce scénario', __FILE__));
 			}
 			$return = 'ok';
 			switch (init('action')) {
 				case 'start':
-					log::add('api', 'debug', __('Démarrage scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Démarrage scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$tags = array();
 					foreach ($_REQUEST as $key => $value) {
 						$tags['#' . $key . '#'] = $value;
@@ -175,73 +175,73 @@ if (init('type') != '') {
 						$scenario->setTags(init('tags'));
 					}
 					$scenario->addTag('trigger','api');
-					$scenario->addTag('trigger_message',__('Scénario exécuté sur appel API', __FILE__));
+					$scenario->addTag('trigger_message',new Trad('Scénario exécuté sur appel API', __FILE__));
 					$scenario_return = $scenario->launch();
 					if (is_string($scenario_return)) {
 						$return = $scenario_return;
 					}
 					break;
 				case 'stop':
-					log::add('api', 'debug', __('Arrêt scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Arrêt scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$scenario->stop();
 					break;
 				case 'deactivate':
-					log::add('api', 'debug', __('Désactivation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Désactivation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$scenario->setIsActive(0);
 					$scenario->save();
 					break;
 				case 'disable':
-					log::add('api', 'debug', __('Désactivation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Désactivation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$scenario->setIsActive(0);
 					$scenario->save();
 					break;
 				case 'activate':
-					log::add('api', 'debug', __('Activation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Activation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$scenario->setIsActive(1);
 					$scenario->save();
 					break;
 				case 'enable':
-					log::add('api', 'debug', __('Activation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
+					log::add('api', 'debug', new Trad('Activation scénario de :', __FILE__) . ' ' . $scenario->getHumanName());
 					$scenario->setIsActive(1);
 					$scenario->save();
 					break;
 				default:
-					throw new Exception(__('Action non trouvée ou invalide [start,stop,deactivate,activate]', __FILE__));
+					throw new Exception(new Trad('Action non trouvée ou invalide [start, stop,deactivate,activate]', __FILE__));
 			}
 			echo $return;
 			die();
 		}
 		if ($type == 'message') {
-			log::add('api', 'debug', __('Demande API pour ajouter un message', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour ajouter un message', __FILE__));
 			message::add(init('category'), init('message'));
 			die();
 		}
 		if ($type == 'object') {
-			log::add('api', 'debug', __('Demande API pour les objets', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les objets', __FILE__));
 			header('Content-Type: application/json');
 			echo json_encode(utils::o2a(jeeObject::all()), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
 			die();
 		}
 		if ($type == 'eqLogic') {
-			log::add('api', 'debug', __('Demande API pour les équipements', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les équipements', __FILE__));
 			header('Content-Type: application/json');
 			echo json_encode(utils::o2a(eqLogic::byObjectId(init('object_id'))), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
 			die();
 		}
 		if ($type == 'command') {
-			log::add('api', 'debug', __('Demande API pour les commandes', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les commandes', __FILE__));
 			header('Content-Type: application/json');
 			echo json_encode(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'))), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
 			die();
 		}
 		if ($type == 'fullData') {
-			log::add('api', 'debug', __('Demande API pour les commandes', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les commandes', __FILE__));
 			header('Content-Type: application/json');
 			echo json_encode(jeeObject::fullData(null,$_USER_GLOBAL), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
 			die();
 		}
 		if ($type == 'variable') {
-			log::add('api', 'debug', __('Demande API pour les variables', __FILE__));
+			log::add('api', 'debug', new Trad('Demande API pour les variables', __FILE__));
 			if (init('value') == '') {
 				$dataStore = dataStore::byTypeLinkIdKey('scenario', -1, trim(init('name')));
 				if (is_object($dataStore)) {
@@ -278,14 +278,14 @@ try {
 
 	if ($jsonrpc->getJsonrpc() != '2.0') {
 		user::failedLogin();
-		throw new Exception(__('Requête invalide. Version JSON-RPC invalide :', __FILE__) . ' ' . $jsonrpc->getJsonrpc(), -32001);
+		throw new Exception(new Trad('Requête invalide. Version JSON-RPC invalide :', __FILE__) . ' ' . $jsonrpc->getJsonrpc(), -32001);
 	}
 
 	if(config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), $jsonrpc->getMethod())){
-		throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__));
+		throw new Exception(new Trad('Cette demande n\'est pas autorisée', __FILE__));
 	}
 	if(config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), $jsonrpc->getMethod())){
-		throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
+		throw new Exception(new Trad('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 	}
 
 	$params = $jsonrpc->getParams();
@@ -294,11 +294,11 @@ try {
 		$params['plugin'] = 'core';
 	}
 	if (in_array($params['plugin'], array('apitts', 'apipro', 'apimarket'))) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 	}
 
 	if (!jeedom::apiModeResult(config::byKey('api::' . $params['plugin'] . '::mode', 'core', 'enable'))) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 	}
 
 	if ($params['plugin'] == 'core') {
@@ -317,19 +317,19 @@ try {
 			if (!isset($params['login']) || !isset($params['password']) || $params['login'] == '' || $params['password'] == '') {
 				user::failedLogin();
 				sleep(5);
-				throw new Exception(__('L\'identifiant ou le mot de passe ne peuvent pas être vide', __FILE__), -32001);
+				throw new Exception(new Trad('L\'identifiant ou le mot de passe ne peuvent pas être vide', __FILE__), -32001);
 			}
 			$user = user::connect($params['login'], $params['password']);
 			if (!is_object($user) || $user->getEnable() != 1) {
 				user::failedLogin();
 				sleep(5);
-				throw new Exception(__('Echec lors de l\'authentification', __FILE__), -32001);
+				throw new Exception(new Trad('Echec lors de l\'authentification', __FILE__), -32001);
 			}
 			if (network::getUserLocation() != 'internal' && $user->getOptions('twoFactorAuthentification', 0) == 1 && $user->getOptions('twoFactorAuthentificationSecret') != '') {
 				if (!isset($params['twoFactorCode']) || trim($params['twoFactorCode']) == '' || !$user->validateTwoFactorCode($params['twoFactorCode'])) {
 					user::failedLogin();
 					sleep(5);
-					throw new Exception(__('Echec lors de l\'authentification', __FILE__), -32001);
+					throw new Exception(new Trad('Echec lors de l\'authentification', __FILE__), -32001);
 				}
 			}
 			$jsonrpc->makeSuccess($user->getHash());
@@ -341,12 +341,12 @@ try {
 	}
 
 	if (!isset($params['apikey']) && !isset($params['api'])) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 	}
 	$apikey = isset($params['apikey']) ? $params['apikey'] : $params['api'];
 
 	if (!jeedom::apiAccess($apikey, $params['plugin']) && !jeedom::apiAccess($apikey, 'core')) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32002);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32002);
 	}
 
 	if ($params['plugin'] != 'core') {
@@ -360,7 +360,7 @@ try {
 	}
 
 	if ($_RESTRICTED) {
-		throw new Exception(__('Aucune méthode correspondante :', __FILE__) . ' ' . $jsonrpc->getMethod(), -32500);
+		throw new Exception(new Trad('Aucune méthode correspondante :', __FILE__) . ' ' . $jsonrpc->getMethod(), -32500);
 	}
 
 	/*             * ************************config*************************** */
@@ -396,7 +396,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeedom::halt') {
 		unautorizedInDemo();
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		jeedom::haltSystem();
 		$jsonrpc->makeSuccess('ok');
@@ -405,7 +405,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeedom::reboot') {
 		unautorizedInDemo();
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		jeedom::rebootSystem();
 		$jsonrpc->makeSuccess('ok');
@@ -414,7 +414,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeedom::update') {
 		unautorizedInDemo();
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		jeedom::update($params['options'], 0);
 		$jsonrpc->makeSuccess('ok');
@@ -423,7 +423,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeedom::backup') {
 		unautorizedInDemo();
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		jeedom::backup(true);
 		$jsonrpc->makeSuccess('ok');
@@ -462,7 +462,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeeObject::byId' || $jsonrpc->getMethod() == 'object::byId') {
 		$object = jeeObject::byId($params['id']);
 		if (!is_object($object)) {
-			throw new Exception(__('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
+			throw new Exception(new Trad('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
 		}
 		$jsonrpc->makeSuccess(utils::o2a($object));
 	}
@@ -474,7 +474,7 @@ try {
 	if ($jsonrpc->getMethod() == 'jeeObject::fullById' || $jsonrpc->getMethod() == 'object::fullById') {
 		$object = jeeObject::byId($params['id']);
 		if (!is_object($object)) {
-			throw new Exception(__('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
+			throw new Exception(new Trad('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
 		}
 		$return = utils::o2a($object);
 		$return['eqLogics'] = array();
@@ -494,7 +494,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'jeeObject::save' || $jsonrpc->getMethod() == 'object::save') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		if (isset($params['id'])) {
@@ -525,7 +525,7 @@ try {
 	if ($jsonrpc->getMethod() == 'summary::byId') {
 		$object = jeeObject::byId($params['id']);
 		if (!is_object($object)) {
-			throw new Exception(__('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
+			throw new Exception(new Trad('Objet introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32601);
 		}
 		if (!isset($params['key'])) {
 			$params['key'] = '';
@@ -554,14 +554,14 @@ try {
 
 	if ($jsonrpc->getMethod() == 'datastore::byTypeLinkIdKey') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a(dataStore::byTypeLinkIdKey($params['type'], $params['linkId'], $params['key'])));
 	}
 
 	if ($jsonrpc->getMethod() == 'datastore::save') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		$dataStore = new dataStore();
@@ -610,10 +610,10 @@ try {
 	if ($jsonrpc->getMethod() == 'eqLogic::byId') {
 		$eqLogic = eqLogic::byId($params['id']);
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32602);
+			throw new Exception(new Trad('EqLogic introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32602);
 		}
 		if (is_object($_USER_GLOBAL) && !$eqLogic->hasRight('r', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		$jsonrpc->makeSuccess(utils::o2a($eqLogic));
 	}
@@ -621,10 +621,10 @@ try {
 	if ($jsonrpc->getMethod() == 'eqLogic::fullById') {
 		$eqLogic = eqLogic::byId($params['id']);
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('EqLogic introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32602);
+			throw new Exception(new Trad('EqLogic introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32602);
 		}
 		if (is_object($_USER_GLOBAL) && !$eqLogic->hasRight('r', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		$return = utils::o2a($eqLogic);
 		$return['cmds'] = array();
@@ -639,7 +639,7 @@ try {
 		$typeEqLogic = $params['eqType_name'];
 		$typeCmd = $typeEqLogic . 'Cmd';
 		if ($typeEqLogic == '' || !class_exists($typeEqLogic) || !class_exists($typeCmd)) {
-			throw new Exception(__('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
+			throw new Exception(new Trad('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
 		}
 		$eqLogic = null;
 		if (isset($params['id'])) {
@@ -650,7 +650,7 @@ try {
 			$eqLogic->setEqType_name($params['eqType_name']);
 		}
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
+			throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
 		utils::a2o($eqLogic, jeedom::fromHumanReadable($params));
 		$eqLogic->save();
@@ -740,10 +740,10 @@ try {
 	if ($jsonrpc->getMethod() == 'cmd::byId') {
 		$cmd = cmd::byId($params['id']);
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32701);
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32701);
 		}
 		if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess($cmd->exportApi());
 	}
@@ -754,7 +754,7 @@ try {
 			foreach ($params['id'] as $id) {
 				$cmd = cmd::byId($id);
 				if (!is_object($cmd)) {
-					throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($id), -32702);
+					throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($id), -32702);
 				}
 				if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
 					continue;
@@ -764,10 +764,10 @@ try {
 					$params['codeAccess'] = '';
 				}
 				if (!$cmd->checkAccessCode($params['codeAccess'])) {
-					throw new Exception(__('Cette action nécessite un code d\'accès', __FILE__), -32005);
+					throw new Exception(new Trad('Cette action nécessite un code d\'accès', __FILE__), -32005);
 				}
 				if ($cmd->getType() == 'action' && $cmd->getConfiguration('actionConfirm') == 1 && $params['confirmAction'] != 1) {
-					throw new Exception(__('Cette action nécessite une confirmation', __FILE__), -32006);
+					throw new Exception(new Trad('Cette action nécessite une confirmation', __FILE__), -32006);
 				}
 				if ($cmd->getType() == 'info') {
 					$return[$id] = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
@@ -778,19 +778,19 @@ try {
 		} else {
 			$cmd = cmd::byId($params['id']);
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+				throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 			}
 			if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-				throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+				throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 			}
 			if (!isset($params['codeAccess'])) {
 				$params['codeAccess'] = '';
 			}
 			if (!$cmd->checkAccessCode($params['codeAccess'])) {
-				throw new Exception(__('Cette action nécessite un code d\'accès', __FILE__), -32005);
+				throw new Exception(new Trad('Cette action nécessite un code d\'accès', __FILE__), -32005);
 			}
 			if ($cmd->getType() == 'action' && $cmd->getConfiguration('actionConfirm') == 1 && $params['confirmAction'] != 1) {
-				throw new Exception(__('Cette action nécessite une confirmation', __FILE__), -32006);
+				throw new Exception(new Trad('Cette action nécessite une confirmation', __FILE__), -32006);
 			}
 			if ($cmd->getType() == 'info') {
 				$return = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
@@ -807,7 +807,7 @@ try {
 			throw new Exception('Commande introuvable : ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess($cmd->getStatistique($params['startTime'], $params['endTime']));
 	}
@@ -818,7 +818,7 @@ try {
 			throw new Exception('Commande introuvable : ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess($cmd->getTendance($params['startTime'], $params['endTime']));
 	}
@@ -829,7 +829,7 @@ try {
 			throw new Exception('Commande introuvable : ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a($cmd->getHistory($params['startTime'], $params['endTime'])));
 	}
@@ -839,18 +839,18 @@ try {
 		if (isset($params['id'])) {
 			$cmd = cmd::byId($params['id']);
 			if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-				throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
+				throw new Exception(new Trad('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 			}
 		} else {
 			$typeEqLogic = $params['eqType_name'];
 			$typeCmd = $typeEqLogic . 'Cmd';
 			if ($typeEqLogic == '' || !class_exists($typeEqLogic) || !class_exists($typeCmd)) {
-				throw new Exception(__('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
+				throw new Exception(new Trad('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
 			}
 		}
 		if (!is_object($cmd)) {
 			if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
-				throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+				throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 			}
 			$cmd = new cmd();
 		}
@@ -865,7 +865,7 @@ try {
 			throw new Exception('Commande introuvable : ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$cmd->hasRight($_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur cette commande', __FILE__), -32701);
 		}
 		if (!isset($params['datetime'])) {
 			$params['datetime'] = null;
@@ -889,10 +889,10 @@ try {
 	if ($jsonrpc->getMethod() == 'scenario::byId') {
 		$scenario = scenario::byId($params['id']);
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32703);
+			throw new Exception(new Trad('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32703);
 		}
 		if (is_object($_USER_GLOBAL) && !$scenario->hasRight('r', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a($scenario));
 	}
@@ -900,17 +900,17 @@ try {
 	if ($jsonrpc->getMethod() == 'scenario::changeState') {
 		$scenario = scenario::byId($params['id']);
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+			throw new Exception(new Trad('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$scenario->hasRight('w', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
 		}
 		if ($params['state'] == 'stop') {
 			$jsonrpc->makeSuccess($scenario->stop());
 		}
 		if ($params['state'] == 'run') {
 			$scenario->addTag('trigger','api');
-			$scenario->addTag('trigger_message',__('Scénario exécuté sur appel API', __FILE__));
+			$scenario->addTag('trigger_message',new Trad('Scénario exécuté sur appel API', __FILE__));
 			$jsonrpc->makeSuccess($scenario->launch());
 		}
 		if ($params['state'] == 'enable') {
@@ -921,16 +921,16 @@ try {
 			$scenario->setIsActive(0);
 			$jsonrpc->makeSuccess($scenario->save());
 		}
-		throw new Exception(__('Le paramètre "state" ne peut être vide et doit avoir pour valeur [run,stop,enable,disable]', __FILE__));
+		throw new Exception(new Trad('Le paramètre "state" ne peut être vide et doit avoir pour valeur [run, stop,enable,disable]', __FILE__));
 	}
 
 	if ($jsonrpc->getMethod() == 'scenario::export') {
 		$scenario = scenario::byId($params['id']);
 		if (!is_object($scenario)) {
-			throw new Exception(__('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+			throw new Exception(new Trad('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 		}
 		if (is_object($_USER_GLOBAL) && !$scenario->hasRight('w', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(array('humanName' => $scenario->getHumanName(), 'export' => $scenario->export('array')));
 	}
@@ -940,12 +940,12 @@ try {
 		if (isset($params['id'])) {
 			$scenario = scenario::byId($params['id']);
 			if (!is_object($scenario)) {
-				throw new Exception(__('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+				throw new Exception(new Trad('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 			}
 		} else if (isset($params['humanName'])) {
 			$scenario = scenario::byString($params['humanName']);
 			if (!is_object($scenario)) {
-				throw new Exception(__('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+				throw new Exception(new Trad('Scénario introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 			}
 		} else {
 			$scenario = new scenario();
@@ -960,7 +960,7 @@ try {
 			$scenario->setName(config::genKey());
 		}
 		if (is_object($_USER_GLOBAL) && !$scenario->hasRight('w', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
 		}
 		$scenario->setTrigger(array());
 		$scenario->setSchedule(array());
@@ -986,7 +986,7 @@ try {
 			$scenario = new scenario();
 		}
 		if (is_object($_USER_GLOBAL) && !$scenario->hasRight('w', $_USER_GLOBAL)) {
-			throw new Exception(__('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits sur ce scénario', __FILE__), -32701);
 		}
 		utils::a2o($scenario, jeedom::fromHumanReadable($params));
 		$scenario->save();
@@ -996,14 +996,14 @@ try {
 	/*             * ************************Log*************************** */
 	if ($jsonrpc->getMethod() == 'log::get') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(log::get($params['log'], $params['start'], $params['nbLine']));
 	}
 
 	if ($jsonrpc->getMethod() == 'log::getDelta') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(log::getDelta(
 			$params['log'],
@@ -1018,14 +1018,14 @@ try {
 
 	if ($jsonrpc->getMethod() == 'log::getLastLine') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(log::getLastLine($params['log']));
 	}
 
 	if ($jsonrpc->getMethod() == 'log::add') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		if (!isset($params['logicalId'])) $params['logicalId'] = '';
 		$jsonrpc->makeSuccess(log::add($params['log'], $params['type'], $params['message'], $params['logicalId']));
@@ -1033,7 +1033,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'log::list') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		if (!isset($params['filtre'])) {
 			$params['filtre'] = null;
@@ -1043,14 +1043,14 @@ try {
 
 	if ($jsonrpc->getMethod() == 'log::empty') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(log::clear($params['log']));
 	}
 
 	if ($jsonrpc->getMethod() == 'log::remove') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		$jsonrpc->makeSuccess(log::remove($params['log']));
@@ -1059,7 +1059,7 @@ try {
 	/*             * ************************Messages*************************** */
 	if ($jsonrpc->getMethod() == 'message::removeAll') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		message::removeAll();
 		$jsonrpc->makeSuccess('ok');
@@ -1067,27 +1067,27 @@ try {
 
 	if ($jsonrpc->getMethod() == 'message::removebyId') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$message = message::byId($params['messageId']);
 		if (is_object($message)) {
 			$message->remove();
 			$jsonrpc->makeSuccess('ok');
 		} else {
-			throw new Exception(__('Impossible de trouver le message :', __FILE__) . ' ' . secureXSS($params['messageId']));
+			throw new Exception(new Trad('Impossible de trouver le message :', __FILE__) . ' ' . secureXSS($params['messageId']));
 		}
 	}
 
 	if ($jsonrpc->getMethod() == 'message::all') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a(message::all()));
 	}
 
 	if ($jsonrpc->getMethod() == 'message::add') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		if (!isset($params['action'])) $params['action'] = '';
 		if (!isset($params['logicalId'])) $params['logicalId'] = '';
@@ -1097,7 +1097,7 @@ try {
 	/*             * ************************Interact*************************** */
 	if ($jsonrpc->getMethod() == 'interact::tryToReply') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		if (isset($params['reply_cmd'])) {
 			$reply_cmd = cmd::byId($params['reply_cmd']);
@@ -1111,7 +1111,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'interactQuery::all') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a(interactQuery::all()));
 	}
@@ -1119,7 +1119,7 @@ try {
 	/*             * ************************USB mapping*************************** */
 	if ($jsonrpc->getMethod() == 'jeedom::getUsbMapping') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$name = (isset($params['name'])) ? $params['name'] : '';
 		$gpio = (isset($params['gpio'])) ? $params['gpio'] : false;
@@ -1129,7 +1129,7 @@ try {
 	/*             * ************************Plugin*************************** */
 	if ($jsonrpc->getMethod() == 'plugin::install') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		if (isset($params['plugin_id'])) {
@@ -1148,7 +1148,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::remove') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		if (isset($params['plugin_id'])) {
@@ -1158,7 +1158,7 @@ try {
 			$update = update::byLogicalId($params['logicalId']);
 		}
 		if (!is_object($update)) {
-			throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
+			throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
 		}
 		$update->remove();
 		$jsonrpc->makeSuccess('ok');
@@ -1166,7 +1166,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::dependancyInfo') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$plugin = plugin::byId($params['plugin_id']);
 		if (!is_object($plugin)) {
@@ -1177,7 +1177,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::dependancyInstall') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId($params['plugin_id']);
@@ -1190,7 +1190,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::deamonInfo') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$plugin = plugin::byId($params['plugin_id']);
 		if (!is_object($plugin)) {
@@ -1201,7 +1201,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::deamonInfoAll') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$deamons_infos = [];
 		foreach ((plugin::listPlugin()) as $plugin) {
@@ -1214,7 +1214,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::deamonStart') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$plugin = plugin::byId($params['plugin_id']);
 		if (!is_object($plugin)) {
@@ -1232,7 +1232,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::deamonStop') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId($params['plugin_id']);
@@ -1245,7 +1245,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'plugin::deamonChangeAutoMode') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		$plugin = plugin::byId($params['plugin_id']);
@@ -1259,21 +1259,21 @@ try {
 	/*             * ************************Update*************************** */
 	if ($jsonrpc->getMethod() == 'update::all') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user', 'restrict'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a(update::all()));
 	}
 
 	if ($jsonrpc->getMethod() == 'update::nbNeedUpdate') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(update::nbNeedUpdate());
 	}
 
 	if ($jsonrpc->getMethod() == 'update::update') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		jeedom::update('', 0);
@@ -1282,7 +1282,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'update::checkUpdate') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		update::checkAllUpdate();
 		$jsonrpc->makeSuccess('ok');
@@ -1290,7 +1290,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'update::doUpdate') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		if (isset($params['plugin_id'])) {
@@ -1300,7 +1300,7 @@ try {
 			$update = update::byLogicalId($params['logicalId']);
 		}
 		if (!is_object($update)) {
-			throw new Exception(__('Impossible de trouver l\'objet', __FILE__));
+			throw new Exception(new Trad('Impossible de trouver l\'objet', __FILE__));
 		}
 		$update->doUpdate();
 		$jsonrpc->makeSuccess('ok');
@@ -1310,7 +1310,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'network::restartDns') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		config::save('market::allowDNS', 1);
@@ -1320,7 +1320,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'network::stopDns') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
 		config::save('market::allowDNS', 0);
@@ -1330,7 +1330,7 @@ try {
 
 	if ($jsonrpc->getMethod() == 'network::dnsRun') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(network::dns_run());
 	}
@@ -1339,14 +1339,14 @@ try {
 
 	if ($jsonrpc->getMethod() == 'user::all') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$jsonrpc->makeSuccess(utils::o2a(user::all()));
 	}
 
 	if ($jsonrpc->getMethod() == 'user::save') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+			throw new Exception(new Trad('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		$user = user::byId($params['id']);
 		if (!is_object($user)) {
@@ -1360,7 +1360,7 @@ try {
 	/*             * ************************************************************************ */
 
 	if (isset($params['plugin']) && $params['plugin'] != '' && $params['plugin'] != 'core') {
-		log::add('api', 'info', __('Demande pour le plugin :', __FILE__) . ' ' . secureXSS($params['plugin']));
+		log::add('api', 'info', new Trad('Demande pour le plugin :', __FILE__) . ' ' . secureXSS($params['plugin']));
 		try {
 			include_file('core', $params['plugin'], 'api', $params['plugin']);
 		} catch (\Exception $e) {
@@ -1374,7 +1374,7 @@ try {
 	if ($jsonrpc->getMethod() == 'getJson') {
 		log::add('api', 'debug', 'Demande du RDK to send with Json');
 		if (!is_object($_USER_GLOBAL)) {
-			throw new Exception(__('Utilisateur non défini', __FILE__), -32500);
+			throw new Exception(new Trad('Utilisateur non défini', __FILE__), -32500);
 		}
 		$registerDevice = $_USER_GLOBAL->getOptions('registerDevice', array());
 		if (!is_array($registerDevice)) {
@@ -1408,7 +1408,7 @@ try {
 		$return[$idBox]['name'] = config::byKey('name');
 		$jsonrpc->makeSuccess($return);
 	}
-	throw new Exception(__('Aucune méthode correspondante :', __FILE__) . ' ' . secureXSS($jsonrpc->getMethod()), -32500);
+	throw new Exception(new Trad('Aucune méthode correspondante :', __FILE__) . ' ' . secureXSS($jsonrpc->getMethod()), -32500);
 	/*         * *********Catch exeption*************** */
 } catch (Exception $e) {
 	$message = $e->getMessage();

--- a/core/api/marketApi.php
+++ b/core/api/marketApi.php
@@ -30,11 +30,11 @@ try {
 	if (!jeedom::apiAccess(init('apikey'), 'apimarket')) {
 		user::failedLogin();
 		sleep(5);
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 	}
 	if (init('action') == 'resync') {
 		if (jeedom::isStarted() && config::byKey('enableCron', 'core', 1, true) == 0) {
-			die(__('Tous les crons sont actuellement désactivés', __FILE__));
+			die(new Trad('Tous les crons sont actuellement désactivés', __FILE__));
 		}
 		$cron = new cron();
 		$cron->setClass('repo_market');
@@ -47,7 +47,7 @@ try {
 
 	if (init('action') == 'pullInstall') {
 		if (jeedom::isStarted() && config::byKey('enableCron', 'core', 1, true) == 0) {
-			die(__('Tous les crons sont actuellement désactivés', __FILE__));
+			die(new Trad('Tous les crons sont actuellement désactivés', __FILE__));
 		}
 		$cron = new cron();
 		$cron->setClass('repo_market');

--- a/core/api/proApi.php
+++ b/core/api/proApi.php
@@ -765,7 +765,6 @@ try {
 				$params['log'],
 				$params['position'],
 				$params['search'],
-				$params['position'],
 				$params['colored'],
 				$params['numbered'],
 				$params['numStart'],

--- a/core/api/proApi.php
+++ b/core/api/proApi.php
@@ -43,20 +43,20 @@ try {
 	$jsonrpc = new jsonrpc($request);
 
 	if ($jsonrpc->getJsonrpc() != '2.0') {
-		throw new Exception(__('Requête invalide. Version JSON-RPC invalide :', __FILE__) . ' ' . $jsonrpc->getJsonrpc(), -32001);
+		throw new Exception(new Trad('Requête invalide. Version JSON-RPC invalide :', __FILE__) . ' ' . $jsonrpc->getJsonrpc(), -32001);
 	}
 
 	$params = $jsonrpc->getParams();
 
 	if (!isset($params['proapi'])) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 	}
 
 	if (!jeedom::apiAccess($params['proapi'], 'apipro')) {
-		throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
+		throw new Exception(new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__), -32001);
 	}
 
-	log::add('api', 'info', __('connexion valide et verifiée :', __FILE__) . ' ' . $jsonrpc->getMethod());
+	log::add('api', 'info', new Trad('connexion valide et verifiée :', __FILE__) . ' ' . $jsonrpc->getMethod());
 
 	/*             * ************************config*************************** */
 	if ($jsonrpc->getMethod() == 'config::byKey') {
@@ -101,7 +101,7 @@ try {
 			if (config::byKey('enableCron', 'core', 1, true) == 0) {
 				$defaut = 1;
 				$result = 'NOK';
-				$advice = __('Erreur cron : les crons sont désactivés. Allez dans Administration -> Moteur de tâches pour les réactiver', __FILE__);
+				$advice = new Trad('Erreur cron : les crons sont désactivés. Allez dans Administration -> Moteur de tâches pour les réactiver', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Cron actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -111,7 +111,7 @@ try {
 			if (config::byKey('enableScenario') == 0 && count(scenario::all()) > 0) {
 				$defaut = 1;
 				$result = 'NOK';
-				$advice = __('Erreur scénario : tous les scénarios sont désactivés. Allez dans Outils -> Scénarios pour les réactiver', __FILE__);
+				$advice = new Trad('Erreur scénario : tous les scénarios sont désactivés. Allez dans Outils -> Scénarios pour les réactiver', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Scénario actif', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -154,7 +154,7 @@ try {
 			$advice = '';
 			if (version_compare(phpversion(), '5.5', '<')) {
 				$defaut = 1;
-				$advice = __('Si vous êtes en version 5.4.x, on vous indiquera quand la version 5.5 sera obligatoire', __FILE__);
+				$advice = new Trad('Si vous êtes en version 5.4.x, on vous indiquera quand la version 5.5 sera obligatoire', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Version PHP', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -178,7 +178,7 @@ try {
 			if (!network::test('internal')) {
 				$defaut = 1;
 				$result = 'NOK';
-				$advice = __('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
+				$advice = new Trad('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Configuration réseau interne', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -188,7 +188,7 @@ try {
 			if (!network::test('external')) {
 				$defaut = 1;
 				$result = 'NOK';
-				$advice = __('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
+				$advice = new Trad('Allez sur Administration -> Configuration -> Réseaux, puis configurez correctement la partie réseau', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Configuration réseau externe', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -204,7 +204,7 @@ try {
 			} else {
 				$result = 'NOK';
 				$defaut = 1;
-				$advice = __('Votre cache n\'est pas sauvegardé. En cas de redémarrage, certaines informations peuvent être perdues. Essayez de lancer (à partir du moteur de tâches) la tâche cache::persist.', __FILE__);
+				$advice = new Trad('Votre cache n\'est pas sauvegardé. En cas de redémarrage, certaines informations peuvent être perdues. Essayez de lancer (à partir du moteur de tâches) la tâche cache::persist.', __FILE__);
 			}
 			$health[] = array('plugin' => 'core', 'type' => 'Persistance du cache', 'defaut' => $defaut, 'result' => $result, 'advice' => $advice);
 
@@ -403,7 +403,7 @@ try {
 			$typeEqLogic = $params['eqType_name'];
 			$typeCmd = $typeEqLogic . 'Cmd';
 			if ($typeEqLogic == '' || !class_exists($typeEqLogic) || !class_exists($typeCmd)) {
-				throw new Exception(__('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
+				throw new Exception(new Trad('Type incorrect (classe commande inexistante)', __FILE__) . secureXSS($typeCmd));
 			}
 			$eqLogic = null;
 			if (isset($params['id'])) {
@@ -498,7 +498,7 @@ try {
 		if ($jsonrpc->getMethod() == 'cmd::byId') {
 			$cmd = cmd::byId($params['id']);
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32701);
+				throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32701);
 			}
 			$jsonrpc->makeSuccess(utils::o2a($cmd));
 		}
@@ -509,14 +509,14 @@ try {
 				foreach ($params['id'] as $id) {
 					$cmd = cmd::byId($id);
 					if (!is_object($cmd)) {
-						throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($id), -32702);
+						throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($id), -32702);
 					}
 					$return[$id] = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
 				}
 			} else {
 				$cmd = cmd::byId($params['id']);
 				if (!is_object($cmd)) {
-					throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+					throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 				}
 				$return = array('value' => $cmd->execCmd($params['options']), 'collectDate' => $cmd->getCollectDate());
 			}
@@ -526,7 +526,7 @@ try {
 		if ($jsonrpc->getMethod() == 'cmd::getStatistique') {
 			$cmd = cmd::byId($params['id']);
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+				throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 			}
 			$jsonrpc->makeSuccess($cmd->getStatistique($params['startTime'], $params['endTime']));
 		}
@@ -534,7 +534,7 @@ try {
 		if ($jsonrpc->getMethod() == 'cmd::getTendance') {
 			$cmd = cmd::byId($params['id']);
 			if (!is_object($cmd)) {
-				throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
+				throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . secureXSS($params['id']), -32702);
 			}
 			$jsonrpc->makeSuccess($cmd->getTendance($params['startTime'], $params['endTime']));
 		}
@@ -570,7 +570,7 @@ try {
 			}
 			if ($params['state'] == 'run') {
 				$scenario->addTag('trigger','api');
-				$scenario->addTag('trigger_message',__('Scénario exécuté sur appel API', __FILE__));
+				$scenario->addTag('trigger_message',new Trad('Scénario exécuté sur appel API', __FILE__));
 				$jsonrpc->makeSuccess($scenario->launch());
 			}
 			if ($params['state'] == 'enable') {
@@ -581,13 +581,13 @@ try {
 				$scenario->setIsActive(0);
 				$jsonrpc->makeSuccess($scenario->save());
 			}
-			throw new Exception(__('Le paramètre "state" ne peut être vide et doit avoir pour valeur [run,stop,enable,disable]', __FILE__));
+			throw new Exception(new Trad('Le paramètre "state" ne peut être vide et doit avoir pour valeur [run, stop,enable,disable]', __FILE__));
 		}
 
 		/*             * ************************JeeNetwork*************************** */
 		if ($jsonrpc->getMethod() == 'jeeNetwork::handshake') {
 			if (config::byKey('jeeNetwork::mode') != 'slave') {
-				throw new Exception(__('Impossible d\'ajouter une box Jeedom non esclave à un réseau Jeedom', __FILE__));
+				throw new Exception(new Trad('Impossible d\'ajouter une box Jeedom non esclave à un réseau Jeedom', __FILE__));
 			}
 			$auiKey = config::byKey('auiKey');
 			if ($auiKey == '') {
@@ -654,11 +654,11 @@ try {
 
 		if ($jsonrpc->getMethod() == 'jeeNetwork::receivedBackup') {
 			if (config::byKey('jeeNetwork::mode') == 'slave') {
-				throw new Exception(__('Seul un maître peut recevoir une sauvegarde', __FILE__));
+				throw new Exception(new Trad('Seul un maître peut recevoir une sauvegarde', __FILE__));
 			}
 			$jeeNetwork = jeeNetwork::byId($params['slave_id']);
 			if (!is_object($jeeNetwork)) {
-				throw new Exception(__('Aucun esclave correspondant à l\'ID :', __FILE__) . ' ' . secureXSS($params['slave_id']));
+				throw new Exception(new Trad('Aucun esclave correspondant à l\'ID :', __FILE__) . ' ' . secureXSS($params['slave_id']));
 			}
 			if (substr(config::byKey('backup::path'), 0, 1) != '/') {
 				$backup_dir = __DIR__ . '/../../' . config::byKey('backup::path');
@@ -670,19 +670,19 @@ try {
 				mkdir($uploaddir);
 			}
 			if (!file_exists($uploaddir)) {
-				throw new Exception(__('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . secureXSS($uploaddir));
+				throw new Exception(new Trad('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . secureXSS($uploaddir));
 			}
 			$_file = $_FILES['file'];
 			$extension = strtolower(strrchr($_file['name'], '.'));
 			if (!in_array($extension, array('.tar.gz', '.gz', '.tar'))) {
-				throw new Exception(__('Extension du fichier non valide (autorisé .tar.gz, .tar et .gz) :', __FILE__) . ' ' . secureXSS($extension));
+				throw new Exception(new Trad('Extension du fichier non valide (autorisé .tar.gz, .tar et .gz) :', __FILE__) . ' ' . secureXSS($extension));
 			}
 			if (filesize($_file['tmp_name']) > 50000000) {
-				throw new Exception(__('La taille du fichier est trop importante (maximum 50Mo)', __FILE__));
+				throw new Exception(new Trad('La taille du fichier est trop importante (maximum 50Mo)', __FILE__));
 			}
 			$uploadfile = $uploaddir . $jeeNetwork->getId() . '-' . $jeeNetwork->getName() . '-' . $jeeNetwork->getConfiguration('version') . '-' . date('Y-m-d_H\hi') . '.tar' . $extension;
 			if (!move_uploaded_file($_file['tmp_name'], $uploadfile)) {
-				throw new Exception(__('Impossible de téléverser le fichier', __FILE__));
+				throw new Exception(new Trad('Impossible de téléverser le fichier', __FILE__));
 			}
 			system('find ' . $uploaddir . $jeeNetwork->getId() . '*' . ' -mtime +' . config::byKey('backup::keepDays') . ' -print | xargs -r rm');
 			$jsonrpc->makeSuccess('ok');
@@ -690,7 +690,7 @@ try {
 
 		if ($jsonrpc->getMethod() == 'jeeNetwork::restoreBackup') {
 			if (config::byKey('jeeNetwork::mode') != 'slave') {
-				throw new Exception(__('Seul un esclave peut restaurer une sauvegarde', __FILE__));
+				throw new Exception(new Trad('Seul un esclave peut restaurer une sauvegarde', __FILE__));
 			}
 			if (substr(config::byKey('backup::path'), 0, 1) != '/') {
 				$uploaddir = __DIR__ . '/../../' . config::byKey('backup::path');
@@ -701,20 +701,20 @@ try {
 				mkdir($uploaddir);
 			}
 			if (!file_exists($uploaddir)) {
-				throw new Exception(__('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . secureXSS($uploaddir));
+				throw new Exception(new Trad('Répertoire de téléversement non trouvé :', __FILE__) . ' ' . secureXSS($uploaddir));
 			}
 			$_file = $_FILES['file'];
 			$extension = strtolower(strrchr($_file['name'], '.'));
 			if (!in_array($extension, array('.tar.gz', '.gz', '.tar'))) {
-				throw new Exception(__('Extension du fichier non valide (autorisé .tar.gz, .tar et .gz) :', __FILE__) . ' ' . secureXSS($extension));
+				throw new Exception(new Trad('Extension du fichier non valide (autorisé .tar.gz, .tar et .gz) :', __FILE__) . ' ' . secureXSS($extension));
 			}
 			if (filesize($_file['tmp_name']) > 50000000) {
-				throw new Exception(__('La taille du fichier est trop importante (maximum 50Mo)', __FILE__));
+				throw new Exception(new Trad('La taille du fichier est trop importante (maximum 50Mo)', __FILE__));
 			}
 			$backup_name = 'backup-' . jeedom::version() . '-' . date("d-m-Y-H\hi") . '.tar.gz';
 			$uploadfile = $uploaddir . '/' . $backup_name;
 			if (!move_uploaded_file($_file['tmp_name'], $uploadfile)) {
-				throw new Exception(__('Impossible de téléverser le fichier', __FILE__));
+				throw new Exception(new Trad('Impossible de téléverser le fichier', __FILE__));
 			}
 			jeedom::restore($uploadfile, true);
 			$jsonrpc->makeSuccess('ok');
@@ -819,7 +819,7 @@ try {
 				$market = market::byLogicalId($params['plugin_id']);
 			}
 			if (!is_object($market)) {
-				throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
+				throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
 			}
 			if (!isset($params['version'])) {
 				$params['version'] = 'stable';
@@ -831,7 +831,7 @@ try {
 		if ($jsonrpc->getMethod() == 'plugin::remove') {
 			$market = market::byId($params['plugin_id']);
 			if (!is_object($market)) {
-				throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
+				throw new Exception(new Trad('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
 			}
 			if (!isset($params['version'])) {
 				$params['version'] = 'stable';
@@ -905,7 +905,7 @@ try {
 
 		/*             * ************************************************************************ */
 	}
-	throw new Exception(__('Aucune méthode correspondante :', __FILE__) . ' ' . secureXSS($jsonrpc->getMethod()), -32500);
+	throw new Exception(new Trad('Aucune méthode correspondante :', __FILE__) . ' ' . secureXSS($jsonrpc->getMethod()), -32500);
 	/*         * *********Catch exeption*************** */
 } catch (Exception $e) {
 	$message = $e->getMessage();

--- a/core/api/tts.php
+++ b/core/api/tts.php
@@ -27,7 +27,7 @@ if (user::isBan()) {
 }
 
 if (!jeedom::apiAccess(init('apikey'), 'apitts')) {
-	echo __('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__);
+	echo new Trad('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__);
 	die();
 }
 
@@ -44,14 +44,14 @@ if (trim($engine) == '') {
 }
 $text = init('text');
 if ($text == '') {
-	echo __('Aucun texte à dire', __FILE__);
+	echo new Trad('Aucun texte à dire', __FILE__);
 	die();
 }
 if (substr(init('text'), -1) == '#' && substr(init('text'), 0, 1) == '#' && class_exists('songs')  && class_exists('songs_song')) {
-	log::add('tts', 'debug', __('Tag detécté dans le tts et plugin song présent', __FILE__));
+	log::add('tts', 'debug', new Trad('Tag detécté dans le tts et plugin song présent', __FILE__));
 	$song = songs_song::byLogicalId(strtolower(str_replace('#', '', init('text'))));
 	if (is_object($song) && file_exists($song->getPath())) {
-		log::add('tts', 'debug', __('Son trouvé path :', __FILE__) . ' ' . $song->getPath());
+		log::add('tts', 'debug', new Trad('Son trouvé path :', __FILE__) . ' ' . $song->getPath());
 		if (init('path') == 1) {
 			echo $song->getPath();
 		} else {
@@ -130,7 +130,7 @@ try {
 			}
 		}
 		if ($older['file'] == null) {
-			log::add('tts', 'error', __('Erreur aucun fichier trouvé à supprimer alors que le répertoire fait :', __FILE__) . ' ' . getDirectorySize($tts_dir));
+			log::add('tts', 'error', new Trad('Erreur aucun fichier trouvé à supprimer alors que le répertoire fait :', __FILE__) . ' ' . getDirectorySize($tts_dir));
 		}
 		unlink($older['file']);
 	}

--- a/core/class/Trad.class.php
+++ b/core/class/Trad.class.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * classe raccourcis pour remplacer la fonction muette __( )
+ * traduction de texte
+ */
+class Trad {
+
+    /** @var string  */
+    private $key;
+
+    /** @var string  */
+    private $file;
+
+    /** @var bool */
+    private $backslash;
+
+    /** @var string */
+    private $prefix;
+
+    /** @var string */
+    private $suffix;
+
+    public function __construct(string $key, string $file = __FILE__, bool $backslash = false, string $prefix = '', string $suffix = '') {
+        $this->key = $key;
+        $this->file = $file;
+        $this->backslash = $backslash;
+        $this->prefix = $prefix;
+        $this->suffix = $suffix;
+    }
+
+    public function __toString(): string {
+        return $this->prefix.\translate::sentence(str_replace("\'", "'", $this->key), $this->file, $this->backslash).$this->suffix;
+    }
+
+}

--- a/core/class/ajax.class.php
+++ b/core/class/ajax.class.php
@@ -46,7 +46,7 @@ class ajax {
 			header('Content-Type: application/json');
 		}
 		if(isset($_GET['action']) && !in_array($_GET['action'], $_allowGetAction)){
-			throw new \Exception(__('Méthode non autorisée en GET : ',__FILE__).$_GET['action']);
+			throw new \Exception(new Trad('Méthode non autorisée en GET : ', __FILE__).$_GET['action']);
 		}
 	}
 

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1042,6 +1042,10 @@ class cmd {
 					return intval($binary xor boolval($this->getConfiguration('invertBinary', false)));
 				case 'numeric':
 					if ($this->getConfiguration('historizeRound') !== '' && is_numeric($this->getConfiguration('historizeRound')) && $this->getConfiguration('historizeRound') >= 0) {
+                        if (!is_numeric($_value)) {
+                            log::add('cmd', 'error', __('La formule de calcul doit retourner une valeur numérique uniquement : ', __FILE__) . $this->getHumanName() . ' => ' . $_value);
+                            $_value = (float) (str_replace(',', '.', $_value));
+                        }
 						$_value = round($_value, $this->getConfiguration('historizeRound'));
 					}
 					if ($_value > $this->getConfiguration('maxValue', $_value)) {

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -534,7 +534,7 @@ class cmd {
 			'cmd_name' => (html_entity_decode($_cmd_name) != '') ? html_entity_decode($_cmd_name) : $_cmd_name,
 		);
 
-		if ($_object_name == __('Aucun', __FILE__)) {
+		if ($_object_name == new Trad('Aucun', __FILE__)) {
 			$sql = 'SELECT ' . DB::buildField(__CLASS__, 'c') . '
 			FROM cmd c
 			INNER JOIN eqLogic el ON c.eqLogic_id=el.id
@@ -772,7 +772,7 @@ class cmd {
 		if (isset($colors[$_color])) {
 			return $colors[$_color];
 		}
-		throw new Exception(__('Impossible de traduire la couleur en code hexadécimal :', __FILE__) . $_color);
+		throw new Exception(new Trad('Impossible de traduire la couleur en code hexadécimal :', __FILE__) . $_color);
 	}
 
 	public static function availableWidget($_version) {
@@ -888,7 +888,7 @@ class cmd {
 
 	public static function getSelectOptionsByTypeAndSubtype($_type = false, $_subtype = false, $_version = 'dashboard', $_availWidgets = false) {
 		if ($_type === false || $_subtype === false) {
-			throw new Exception(__('Type ou sous-type de commande invalide', __FILE__));
+			throw new Exception(new Trad('Type ou sous-type de commande invalide', __FILE__));
 		}
 		if (!$_availWidgets) {
 			$_availWidgets = self::availableWidget($_version);
@@ -1074,19 +1074,19 @@ class cmd {
 
 	public function save($_direct = false) {
 		if ($this->getName() == '') {
-			throw new Exception(__('Le nom de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
+			throw new Exception(new Trad('Le nom de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
 		}
 		if ($this->getType() == '') {
-			throw new Exception($this->getHumanName() . ' ' . __('Le type de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
+			throw new Exception($this->getHumanName() . ' ' . new Trad('Le type de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
 		}
 		if ($this->getSubType() == '') {
-			throw new Exception($this->getHumanName() . ' ' . __('Le sous-type de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
+			throw new Exception($this->getHumanName() . ' ' . new Trad('Le sous-type de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
 		}
 		if ($this->getEqLogic_id() == '') {
-			throw new Exception($this->getHumanName() . ' ' . __('Vous ne pouvez pas créer une commande sans la rattacher à un équipement', __FILE__));
+			throw new Exception($this->getHumanName() . ' ' . new Trad('Vous ne pouvez pas créer une commande sans la rattacher à un équipement', __FILE__));
 		}
 		if ($this->getConfiguration('maxValue') != '' && $this->getConfiguration('minValue') != '' && $this->getConfiguration('minValue') > $this->getConfiguration('maxValue')) {
-			throw new Exception($this->getHumanName() . ' ' . __('La valeur minimum de la commande ne peut être supérieure à la valeur maximum', __FILE__));
+			throw new Exception($this->getHumanName() . ' ' . new Trad('La valeur minimum de la commande ne peut être supérieure à la valeur maximum', __FILE__));
 		}
 		if ($this->getEqType() == '') {
 			$this->setEqType($this->getEqLogic()->getEqType_name());
@@ -1163,10 +1163,10 @@ class cmd {
 		$message = '';
 		switch ($_type) {
 			case 'jeedomPreExecCmd':
-				$message = '. ' . __('Sur preExec de la commande', __FILE__);
+				$message = '. ' . new Trad('Sur preExec de la commande', __FILE__);
 				break;
 			case 'jeedomPostExecCmd':
-				$message = '. ' . __('Sur postExec de la commande', __FILE__);
+				$message = '. ' . new Trad('Sur postExec de la commande', __FILE__);
 				break;
 		}
 
@@ -1188,7 +1188,7 @@ class cmd {
 				}
 				scenarioExpression::createAndExec('action', $action['cmd'], $options);
 			} catch (Exception $e) {
-				log::add('cmd', 'error', __('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . ': ' . $message . '. ' . $this->getHumanName() . __('Détails :', __FILE__) . ' ' . log::exception($e));
+				log::add('cmd', 'error', new Trad('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . ': ' . $message . '. ' . $this->getHumanName() . new Trad('Détails :', __FILE__) . ' ' . log::exception($e));
 			}
 		}
 	}
@@ -1314,14 +1314,14 @@ class cmd {
 			}
 			if ($this->isAlreadyInStateAllow() && $this->alreadyInState($options)) {
 				if (is_array($options) && ((count($options) > 1 && isset($options['uid'])) || count($options) > 0)) {
-					log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . __('avec les paramètres', __FILE__) . ' ' . json_encode($options) . ' ' . __('(ignorée)', __FILE__));
+					log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . new Trad('avec les paramètres', __FILE__) . ' ' . json_encode($options) . ' ' . new Trad('(ignorée)', __FILE__));
 				} else {
-					log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . __('(ignorée)', __FILE__));
+					log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . new Trad('(ignorée)', __FILE__));
 				}
 				return;
 			}
 			if (is_array($options) && ((count($options) > 1 && isset($options['uid'])) || count($options) > 0)) {
-				log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . __('avec les paramètres', __FILE__) . ' ' . json_encode($options));
+				log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName() . ' ' . new Trad('avec les paramètres', __FILE__) . ' ' . json_encode($options));
 			} else {
 				log::add('event', 'info', $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $this->getHumanName());
 			}
@@ -1348,14 +1348,14 @@ class cmd {
 				$numberTryWithoutSuccess = $eqLogic->getStatus('numberTryWithoutSuccess', 0);
 				$eqLogic->setStatus('numberTryWithoutSuccess', $numberTryWithoutSuccess);
 				if ($numberTryWithoutSuccess >= config::byKey('numberOfTryBeforeEqLogicDisable')) {
-					$message = __('Désactivation de', __FILE__) . ' <a href="' . $eqLogic->getLinkToConfiguration() . '"> ' . $eqLogic->getName() . '</a> ' . __('car il n\'a pas répondu ou mal répondu lors des 3 derniers essais', __FILE__);
-					$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+					$message = new Trad('Désactivation de', __FILE__) . ' <a href="' . $eqLogic->getLinkToConfiguration() . '"> ' . $eqLogic->getName() . '</a> ' . new Trad('car il n\'a pas répondu ou mal répondu lors des 3 derniers essais', __FILE__);
+					$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 					message::add($type, $message, $action);
 					$eqLogic->setIsEnable(0);
 					$eqLogic->save();
 				}
 			}
-			log::add($type, 'error', __('Erreur exécution de la commande', __FILE__) . ' ' . $this->getHumanName() . ' : ' . log::exception($e));
+			log::add($type, 'error', new Trad('Erreur exécution de la commande', __FILE__) . ' ' . $this->getHumanName() . ' : ' . log::exception($e));
 			throw $e;
 		}
 		if ($options !== null && $this->getValue() == '') {
@@ -1401,7 +1401,7 @@ class cmd {
 			$this->setTemplate($_version, 'core::default');
 			$this->save(true);
 		}
-		$display = '<option value="core::default">' . __('Défaut', __FILE__) . '</option>';
+		$display = '<option value="core::default">' . new Trad('Défaut', __FILE__) . '</option>';
 		return $display .= self::getSelectOptionsByTypeAndSubtype($this->getType(), $this->getSubType(), $_version, $_availWidgets);
 	}
 
@@ -1450,7 +1450,7 @@ class cmd {
 			$widgetHelp = explode('</template>', $widgetCode)[0];
 			$widgetHelp = explode('<template>', $widgetHelp)[1];
 			if ($widgetHelp == '') {
-				return '<em>' . __('Aucun paramètre optionnel disponible.', __FILE__) . '</em>';
+				return '<em>' . new Trad('Aucun paramètre optionnel disponible.', __FILE__) . '</em>';
 			} else {
 				$widgetHelp = strip_tags($widgetHelp, '<div>');
 				if ($isCorewidget) {
@@ -1460,7 +1460,7 @@ class cmd {
 				}
 			}
 		} else {
-			return '<em>' . __('Aucune description trouvée pour ce Widget.', __FILE__) . '</em>';
+			return '<em>' . new Trad('Aucune description trouvée pour ce Widget.', __FILE__) . '</em>';
 		}
 	}
 
@@ -1813,15 +1813,15 @@ class cmd {
 				return $html;
 			}
 
-			$replace['#title_placeholder#'] = $this->getDisplay('title_placeholder', __('Titre', __FILE__));
-			$replace['#message_placeholder#'] = $this->getDisplay('message_placeholder', __('Message', __FILE__));
+			$replace['#title_placeholder#'] = $this->getDisplay('title_placeholder', new Trad('Titre', __FILE__));
+			$replace['#message_placeholder#'] = $this->getDisplay('message_placeholder', new Trad('Message', __FILE__));
 			$replace['#message_cmd_type#'] = $this->getDisplay('message_cmd_type', 'info');
 			$replace['#message_cmd_subtype#'] = $this->getDisplay('message_cmd_subtype', '');
 			$replace['#message_disable#'] = $this->getDisplay('message_disable', 0);
 			$replace['#title_disable#'] = $this->getDisplay('title_disable', 0);
 			$replace['#title_color#'] = $this->getDisplay('title_color', 0);
 			$replace['#title_possibility_list#'] = str_replace("'", "\'", $this->getDisplay('title_possibility_list', ''));
-			$replace['#slider_placeholder#'] = $this->getDisplay('slider_placeholder', __('Valeur', __FILE__));
+			$replace['#slider_placeholder#'] = $this->getDisplay('slider_placeholder', new Trad('Valeur', __FILE__));
 			$replace['#other_tooltips#'] = ($replace['#name#'] != $this->getName()) ? $this->getName() : '';
 
 			$parameters = $this->getDisplay('parameters');
@@ -1872,7 +1872,7 @@ class cmd {
 		$value = $this->formatValue($_value);
 
 		if ($this->getSubType() == 'numeric' && ($value > $this->getConfiguration('maxValue', $value) || $value < $this->getConfiguration('minValue', $value)) && strpos($value, 'error') === false) {
-			log::add('cmd', 'info', __('La commande n\'est pas dans la plage de valeur autorisée :', __FILE__) . ' ' . $this->getHumanName() . ' => ' . $value);
+			log::add('cmd', 'info', new Trad('La commande n\'est pas dans la plage de valeur autorisée :', __FILE__) . ' ' . $this->getHumanName() . ' => ' . $value);
 			return;
 		}
 		if ($this->getConfiguration('denyValues') != '' && in_array($value, explode(';', $this->getConfiguration('denyValues')))) {
@@ -1911,7 +1911,7 @@ class cmd {
 		if ($repeat && $this->getConfiguration('repeatEventManagement', 'never') == 'always') {
 			$repeat = false;
 		}
-		$message = __('Evènement sur la commande', __FILE__) . ' ' . $this->getHumanName() . ' ' . __('valeur :', __FILE__) . ' ' . $value . $this->getUnite();
+		$message = new Trad('Evènement sur la commande', __FILE__) . ' ' . $this->getHumanName() . ' ' . new Trad('valeur :', __FILE__) . ' ' . $value . $this->getUnite();
 		if ($repeat) {
 			$message .= ' (répétition)';
 		}
@@ -2046,7 +2046,7 @@ class cmd {
 				$options['source'] = $this->getHumanName();
 				scenarioExpression::createAndExec('action', $action['cmd'], $options);
 			} catch (Exception $e) {
-				log::add('cmd', 'error', __('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . __('. Détails :', __FILE__) . ' ' . log::exception($e));
+				log::add('cmd', 'error', new Trad('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . new Trad('. Détails :', __FILE__) . ' ' . log::exception($e));
 			}
 		}
 	}
@@ -2145,14 +2145,14 @@ class cmd {
 			$_value = $this->execCmd();
 		}
 		if ($_level != 'none') {
-			$message = __('Alerte sur la commande', __FILE__) . ' ' . $this->getHumanName() . ' ' . __('niveau', __FILE__) . ' ' . $_level . ' ' . __('valeur :', __FILE__) . ' ' . $_value . trim(' ' . $this->getUnite());
+			$message = new Trad('Alerte sur la commande', __FILE__) . ' ' . $this->getHumanName() . ' ' . new Trad('niveau', __FILE__) . ' ' . $_level . ' ' . new Trad('valeur :', __FILE__) . ' ' . $_value . trim(' ' . $this->getUnite());
 			if ($this->getAlert($_level . 'during') != '' && $this->getAlert($_level . 'during') > 0) {
-				$message .= ' ' . __('pendant plus de', __FILE__) . ' ' . $this->getAlert($_level . 'during') . ' ' . __('minute(s)', __FILE__);
+				$message .= ' ' . new Trad('pendant plus de', __FILE__) . ' ' . $this->getAlert($_level . 'during') . ' ' . new Trad('minute(s)', __FILE__);
 			}
 			$message .= ' => ' . jeedom::toHumanReadable(str_replace('#value#', $_value, $this->getAlert($_level . 'if')));
 			log::add('event', 'info', $message);
 			if (config::byKey('alert::addMessageOn' . ucfirst($_level)) == 1) {
-				$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+				$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 				message::add($eqLogic->getEqType_name(), $message, $action, 'alert_' . $this->getId() . '_' . strtotime('now') . '_' . rand(0, 999), true, 'alerting');
 			}
 			$cmds = explode(('&&'), config::byKey('alert::' . $_level . 'Cmd'));
@@ -2166,15 +2166,15 @@ class cmd {
 								'message' => config::byKey('name', 'core', 'JEEDOM') . ' : ' . $message,
 							));
 						} catch (Exception $e) {
-							log::add('jeedomAlert', 'error', __('Erreur lors de l\'envoi de l\'alerte : ', __FILE__) . ' ' . $cmd->getHumanName() . '  => ' . log::exception($e));
+							log::add('jeedomAlert', 'error', new Trad('Erreur lors de l\'envoi de l\'alerte : ', __FILE__) . ' ' . $cmd->getHumanName() . '  => ' . log::exception($e));
 						}
 					}
 				}
 			}
 		} elseif ($this->getConfiguration('alert::messageReturnBack') == 1) {
-			$message = __('Retour à la normale de ', __FILE__) . ' ' . $this->getHumanName() . ' ' . __('valeur :', __FILE__) . ' ' . $_value . trim(' ' . $this->getUnite());
+			$message = new Trad('Retour à la normale de ', __FILE__) . ' ' . $this->getHumanName() . ' ' . new Trad('valeur :', __FILE__) . ' ' . $_value . trim(' ' . $this->getUnite());
 			log::add('event', 'info', $message);
-			$action = '<a href="/' . $this->getEqLogic()->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+			$action = '<a href="/' . $this->getEqLogic()->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 			message::add($this->getEqLogic()->getEqType_name(), $message, $action, 'alertReturnBack_' . $this->getId() . '_' . strtotime('now') . '_' . rand(0, 999), true, 'alertingReturnBack');
 		}
 
@@ -2208,15 +2208,15 @@ class cmd {
 			'"' => ''
 		);
 		$url = str_replace(array_keys($replace), $replace, scenarioExpression::setTags($url));
-		log::add('event', 'info', __('Appels de l\'URL de push pour la commande', __FILE__) . ' ' . $this->getHumanName() . ' : ' . $url);
+		log::add('event', 'info', new Trad('Appels de l\'URL de push pour la commande', __FILE__) . ' ' . $this->getHumanName() . ' : ' . $url);
 		$http = new com_http($url);
 		$http->setLogError(false);
 		try {
 			$http->exec();
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur push sur :', __FILE__) . ' ' . $url . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur push sur :', __FILE__) . ' ' . $url . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		} catch (Error $e) {
-			log::add('cmd', 'error', __('Erreur push sur :', __FILE__) . ' ' . $url . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur push sur :', __FILE__) . ' ' . $url . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		}
 	}
 
@@ -2272,7 +2272,7 @@ class cmd {
 			}
 			log::add('cmd', 'debug', 'Push influx for ' . $this->getHumanName() . ' : ' .  json_encode($tagArray, true));
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur computing influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur computing influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		}
 		return $point;
 	}
@@ -2308,7 +2308,7 @@ class cmd {
 			}
 			return $database;
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur get influx database :', __FILE__) . ' ' . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur get influx database :', __FILE__) . ' ' . ' => ' . log::exception($e));
 		}
 		return '';
 	}
@@ -2325,7 +2325,7 @@ class cmd {
 			$point = $this->computeInfluxData($_value);
 			$result = $database->writePoints(array($point), 's');
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur push influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur push influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		}
 		return;
 	}
@@ -2338,7 +2338,7 @@ class cmd {
 			}
 			$database->drop();
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur delete influx sur :', __FILE__) . ' ' . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur delete influx sur :', __FILE__) . ' ' . ' => ' . log::exception($e));
 		}
 		return;
 	}
@@ -2353,7 +2353,7 @@ class cmd {
 			$result = $database->query($query);
 			log::add('cmd', 'debug', 'Delete influx for ' . $this->getHumanName());
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur delete influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur delete influx sur :', __FILE__) . ' ' . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		}
 		return;
 	}
@@ -2375,7 +2375,7 @@ class cmd {
 		}
 		try {
 			foreach ($cmds as $cmd) {
-				log::add('cmd', 'info', __('Envoie de l\'historique à influx :', __FILE__) . ' ' . ' commande : ' . $cmd->getHumanName());
+				log::add('cmd', 'info', new Trad('Envoie de l\'historique à influx :', __FILE__) . ' ' . ' commande : ' . $cmd->getHumanName());
 				$database = cmd::getInflux($cmd->getId());
 				if ($database == '') {
 					return;
@@ -2404,7 +2404,7 @@ class cmd {
 				}
 			}
 		} catch (Exception $e) {
-			log::add('cmd', 'error', __('Erreur history influx sur :', __FILE__) . ' ' . ' commande : ' . $cmd->getHumanName() . ' => ' . log::exception($e));
+			log::add('cmd', 'error', new Trad('Erreur history influx sur :', __FILE__) . ' ' . ' commande : ' . $cmd->getHumanName() . ' => ' . log::exception($e));
 		}
 	}
 
@@ -2613,11 +2613,11 @@ class cmd {
 	public static function migrateCmd($_sourceId, $_targetId) {
 		$sourceCmd = cmd::byId($_sourceId);
 		if (!is_object($sourceCmd)) {
-			throw new Exception(__('La commande source n\'existe pas', __FILE__));
+			throw new Exception(new Trad('La commande source n\'existe pas', __FILE__));
 		}
 		$targetCmd = cmd::byId($_targetId);
 		if (!is_object($targetCmd)) {
-			throw new Exception(__('La commande cible n\'existe pas', __FILE__));
+			throw new Exception(new Trad('La commande cible n\'existe pas', __FILE__));
 		}
 
 		$migrateDisplayValues = [
@@ -2739,7 +2739,7 @@ class cmd {
 			$targetCmd->save();
 			return $targetCmd;
 		} catch (Exception $e) {
-			throw new Exception(__('Erreur lors de la migration de commande', __FILE__) . ' : ' . log::exception($e));
+			throw new Exception(new Trad('Erreur lors de la migration de commande', __FILE__) . ' : ' . log::exception($e));
 		}
 	}
 
@@ -2831,7 +2831,7 @@ class cmd {
 		$_data['node']['cmd' . $this->getId()] = array(
 			'id' => 'cmd' . $this->getId(),
 			'name' => $this->getName(),
-			'type' => __('Commande', __FILE__),
+			'type' => new Trad('Commande', __FILE__),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],
 			'fontsize' => '1.5em',

--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -17,7 +17,7 @@
 */
 
 /* * ***************************Includes********************************* */
-require_once __DIR__ . '/../../core/php/core.inc.php';
+// require_once __DIR__ . '/../../core/php/core.inc.php';
 
 class config {
 	/*     * *************************Attributs****************************** */

--- a/core/class/cron.class.php
+++ b/core/class/cron.class.php
@@ -201,10 +201,10 @@ class cron {
 	*/
 	public function preSave() {
 		if ($this->getFunction() == '') {
-			throw new Exception(__('La fonction ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('La fonction ne peut pas être vide', __FILE__));
 		}
 		if ($this->getSchedule() == '') {
-			throw new Exception(__('La programmation ne peut pas être vide :', __FILE__) . ' ' . print_r($this, true));
+			throw new Exception(new Trad('La programmation ne peut pas être vide :', __FILE__) . ' ' . print_r($this, true));
 		}
 		if ($this->getOption() == '' || count($this->getOption()) == 0) {
 			$cron = cron::byClassAndFunction($this->getClass(), $this->getFunction());
@@ -266,7 +266,7 @@ class cron {
 				if (!$this->running()) {
 					system::php($cmd . ' >> ' . log::getPathToLog('cron_execution') . ' 2>&1 &');
 				} else {
-					throw new Exception(__('Impossible d\'exécuter la tâche car elle est déjà en cours d\'exécution (', __FILE__) . ' : ' . $cmd);
+					throw new Exception(new Trad('Impossible d\'exécuter la tâche car elle est déjà en cours d\'exécution (', __FILE__) . ' : ' . $cmd);
 				}
 			}
 		}
@@ -319,7 +319,7 @@ class cron {
 			$this->setState('stop');
 			$this->setPID();
 		} else {
-			log::add('cron', 'info', __('Arrêt de', __FILE__) . ' ' . $this->getClass() . '::' . $this->getFunction() . '(), PID : ' . $this->getPID());
+			log::add('cron', 'info', new Trad('Arrêt de', __FILE__) . ' ' . $this->getClass() . '::' . $this->getFunction() . '(), PID : ' . $this->getPID());
 			if ($this->getPID() > 0) {
 				system::kill($this->getPID());
 				$retry = 0;
@@ -345,7 +345,7 @@ class cron {
 				if ($this->running()) {
 					$this->setState('error');
 					$this->setPID();
-					throw new Exception($this->getClass() . '::' . $this->getFunction() . __('() : Impossible d\'arrêter la tâche', __FILE__));
+					throw new Exception($this->getClass() . '::' . $this->getFunction() . new Trad('() : Impossible d\'arrêter la tâche', __FILE__));
 				}
 			} else {
 				$this->setState('stop');

--- a/core/class/dataStore.class.php
+++ b/core/class/dataStore.class.php
@@ -90,13 +90,13 @@ class dataStore {
 	public function preSave() {
 		$allowType = array('cmd', 'object', 'eqLogic', 'scenario');
 		if (!in_array($this->getType(), $allowType)) {
-			throw new Exception(__('Le type doit être un des suivants :', __FILE__) . ' ' . print_r($allowType, true));
+			throw new Exception(new Trad('Le type doit être un des suivants :', __FILE__) . ' ' . print_r($allowType, true));
 		}
 		if (!is_numeric($this->getLink_id())) {
-			throw new Exception(__('Link_id doit être un chiffre', __FILE__));
+			throw new Exception(new Trad('Link_id doit être un chiffre', __FILE__));
 		}
 		if ($this->getKey() == '') {
-			throw new Exception(__('La clef ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('La clef ne peut pas être vide', __FILE__));
 		}
 		if ($this->getId() == '') {
 			$dataStore = self::byTypeLinkIdKey($this->getType(), $this->getLink_id(), $this->getKey());
@@ -143,7 +143,7 @@ class dataStore {
 		$icon = findCodeIcon('fa-code');
 		$_data['node']['dataStore' . $this->getId()] = array(
 			'id' => 'dataStore' . $this->getId(),
-			'type' => __('Variable',__FILE__),
+			'type' => new Trad('Variable', __FILE__),
 			'name' => $this->getKey(),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],
@@ -151,7 +151,7 @@ class dataStore {
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
 			'texty' => -14,
 			'textx' => 0,
-			'title' => __('Variable :', __FILE__) . ' ' . $this->getKey(),
+			'title' => new Trad('Variable :', __FILE__) . ' ' . $this->getKey(),
 		);
 		$usedBy = $this->getUsedBy();
 		addGraphLink($this, 'dataStore', $usedBy['scenario'], 'scenario', $_data, $_level, $_drill);

--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -388,9 +388,9 @@ class eqLogic {
 				$noReponseTimeLimit = $eqLogic->getTimeout();
 				if (count(message::byPluginLogicalId('core', $logicalId)) == 0) {
 					if ($eqLogic->getStatus('lastCommunication', date('Y-m-d H:i:s')) < date('Y-m-d H:i:s', strtotime('-' . $noReponseTimeLimit . ' minutes' . date('Y-m-d H:i:s')))) {
-						$message = __('Attention', __FILE__) . ' ' . $eqLogic->getHumanName();
-						$message .= ' ' . __('n\'a pas envoyé de message depuis plus de', __FILE__) . ' ' . $noReponseTimeLimit . ' ' . __('min', __FILE__);
-						$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+						$message = new Trad('Attention', __FILE__) . ' ' . $eqLogic->getHumanName();
+						$message .= ' ' . new Trad('n\'a pas envoyé de message depuis plus de', __FILE__) . ' ' . $noReponseTimeLimit . ' ' . new Trad('min', __FILE__);
+						$action = '<a href="/' . $eqLogic->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 						$prevStatus = $eqLogic->getStatus('timeout', 0);
 						$eqLogic->setStatus('timeout', 1);
 						if (config::byKey('alert::addMessageOnTimeout') == 1 && $prevStatus == 0) {
@@ -435,7 +435,7 @@ class eqLogic {
 	}
 
 	public static function byObjectNameEqLogicName($_object_name, $_eqLogic_name) {
-		if ($_object_name == __('Aucun', __FILE__)) {
+		if ($_object_name == new Trad('Aucun', __FILE__)) {
 			$values = array(
 				'eqLogic_name' => $_eqLogic_name,
 			);
@@ -552,7 +552,7 @@ class eqLogic {
 	public static function byString($_string) {
 		$eqLogic = self::byId(str_replace(array('#', 'eqLogic'), '', self::fromHumanReadable($_string)));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('L\'équipement n\'a pas pu être trouvé :', __FILE__) . ' ' . $_string . ' => ' . self::fromHumanReadable($_string));
+			throw new Exception(new Trad('L\'équipement n\'a pas pu être trouvé :', __FILE__) . ' ' . $_string . ' => ' . self::fromHumanReadable($_string));
 		}
 		return $eqLogic;
 	}
@@ -651,7 +651,7 @@ class eqLogic {
 		$html .= '<i class="icon jeedom-batterie' . $niveau . '"></i>';
 		$html .= '<span>' . $this->getStatus('battery', -2) . '%</span>';
 		$html .= '</div>';
-		$html .= '<div>' . __('Le', __FILE__) . ' ' . date("Y-m-d H:i:s", strtotime($this->getStatus('batteryDatetime', __('inconnue', __FILE__)))) . '</div>';
+		$html .= '<div>' . new Trad('Le', __FILE__) . ' ' . date("Y-m-d H:i:s", strtotime($this->getStatus('batteryDatetime', new Trad('inconnue', __FILE__)))) . '</div>';
 		$html .= '<br>';
 		$html .= '<span class="pull-left pluginName">' . ucfirst($this->getEqType_name()) . '</span>';
 		if ($_version == 'mobile') {
@@ -660,18 +660,18 @@ class eqLogic {
 			$html .= '<span class="pull-left batteryTime cursor">';
 		}
 		if ($this->getConfiguration('battery_danger_threshold') != '' || $this->getConfiguration('battery_warning_threshold') != '') {
-			$html .= '<i class="icon techno-fingerprint41 pull-right" title="' . __('Seuil manuel défini', __FILE__) . '"></i>';
+			$html .= '<i class="icon techno-fingerprint41 pull-right" title="' . new Trad('Seuil manuel défini', __FILE__) . '"></i>';
 		}
 		if ($batteryTime != 'NA') {
-			$text = __('Pile(s) changée(s) il y a', __FILE__) . ' ';
-			$text .= ($batterySince > 1) ? $batterySince . __('jours', __FILE__) . ' (' . $batteryTime . ')' : $batterySince . __('jour', __FILE__) . ' (' . $batteryTime . ')';
+			$text = new Trad('Pile(s) changée(s) il y a', __FILE__) . ' ';
+			$text .= ($batterySince > 1) ? $batterySince . new Trad('jours', __FILE__) . ' (' . $batteryTime . ')' : $batterySince . new Trad('jour', __FILE__) . ' (' . $batteryTime . ')';
 			$html .= '<i class="icon divers-calendar2" title="' . $text . '"></i><span> (' . $batterySince . 'j)</span>';
 		} else {
-			$html .= '<i class="icon divers-calendar2" title="' . __('Pas de date de changement de pile(s) renseignée', __FILE__) . '"></i>';
+			$html .= '<i class="icon divers-calendar2" title="' . new Trad('Pas de date de changement de pile(s) renseignée', __FILE__) . '"></i>';
 		}
 		$html .= '</span>';
 		if ($this->getConfiguration('battery_type', '') != '') {
-			$html .= '<span class="pull-right" title="' . __('Piles', __FILE__) . '">' . $this->getConfiguration('battery_type', '') . '</span>';
+			$html .= '<span class="pull-right" title="' . new Trad('Piles', __FILE__) . '">' . $this->getConfiguration('battery_type', '') . '</span>';
 		}
 		$html .= '</div>';
 		return $html;
@@ -752,7 +752,7 @@ class eqLogic {
 	public function preToHtml($_version = 'dashboard', $_default = array(), $_noCache = false) {
 		global $JEEDOM_INTERNAL_CONFIG;
 		if ($_version == '') {
-			throw new Exception(__('La version demandée ne peut pas être vide (mobile, dashboard ou scénario)', __FILE__));
+			throw new Exception(new Trad('La version demandée ne peut pas être vide (mobile, dashboard ou scénario)', __FILE__));
 		}
 		if (!$this->hasRight('r') || !$this->getIsEnable()) {
 			return '';
@@ -775,7 +775,7 @@ class eqLogic {
 			'#translate_category#' => $translate_category,
 			'#style#' => '',
 			'#logicalId#' => $this->getLogicalId(),
-			'#object_name#' => (is_object($this->getObject())) ? $this->getObject()->getName() : __('Aucun', __FILE__),
+			'#object_name#' => (is_object($this->getObject())) ? $this->getObject()->getName() : new Trad('Aucun', __FILE__),
 			'#height#' => $this->getDisplay('height', 'auto'),
 			'#width#' => $this->getDisplay('width', 'auto'),
 			'#uid#' => $uid,
@@ -992,7 +992,7 @@ class eqLogic {
 
 	public function save($_direct = false) {
 		if ($this->getName() == '') {
-			throw new Exception(__('Le nom de l\'équipement ne peut pas être vide :', __FILE__) . ' ' . print_r($this, true));
+			throw new Exception(new Trad('Le nom de l\'équipement ne peut pas être vide :', __FILE__) . ' ' . print_r($this, true));
 		}
 		if ($this->getChanged()) {
 			if ($this->getId() != '') {
@@ -1101,9 +1101,9 @@ class eqLogic {
 			$name .= $object->getHumanName($_tag, $_prettify);
 		} else {
 			if ($_tag) {
-				$name .= '<span class="label labelObjectHuman" style="text-shadow : none;">' . __('Aucun', __FILE__) . '</span>';
+				$name .= '<span class="label labelObjectHuman" style="text-shadow : none;">' . new Trad('Aucun', __FILE__) . '</span>';
 			} else {
-				$name .= '[' . __('Aucun', __FILE__) . ']';
+				$name .= '[' . new Trad('Aucun', __FILE__) . ']';
 			}
 		}
 		if ($_prettify) {
@@ -1168,7 +1168,7 @@ class eqLogic {
 			if ($this->getConfiguration('battery_type') != '') {
 				$message .= ' (' . $this->getConfiguration('battery_type') . ')';
 			}
-			$action = '<a href="/' . $this->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+			$action = '<a href="/' . $this->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 			$logicalId = 'lowBattery' . $this->getId();
 			$this->setStatus('batterydanger', 1);
 			if ($prevStatus == 0) {
@@ -1197,7 +1197,7 @@ class eqLogic {
 			if ($this->getConfiguration('battery_type') != '') {
 				$message .= ' (' . $this->getConfiguration('battery_type') . ')';
 			}
-			$action = '<a href="/' . $this->getLinkToConfiguration() . '">' . __('Equipement', __FILE__) . '</a>';
+			$action = '<a href="/' . $this->getLinkToConfiguration() . '">' . new Trad('Equipement', __FILE__) . '</a>';
 			$logicalId = 'warningBattery' . $this->getId();
 			$this->setStatus('batterywarning', 1);
 			$this->setStatus('batterydanger', 0);
@@ -1211,7 +1211,7 @@ class eqLogic {
 						$cmd = cmd::byId(str_replace('#', '', $id));
 						if (is_object($cmd)) {
 							$cmd->execCmd(array(
-								'title' => __('[' . config::byKey('name', 'core', 'JEEDOM') . ']', __FILE__) . ' ' . $message,
+								'title' => new Trad('[' . config::byKey('name', 'core', 'JEEDOM') . ']', __FILE__) . ' ' . $message,
 								'message' => config::byKey('name', 'core', 'JEEDOM') . ' : ' . $message,
 							));
 						}
@@ -1258,11 +1258,11 @@ class eqLogic {
 	public static function migrateEqlogic($_sourceId, $_targetId, $_mode = 'replace') {
 		$sourceEq = eqLogic::byId($_sourceId);
 		if (!is_object($sourceEq)) {
-			throw new Exception(__('L\'équipement source n\'existe pas', __FILE__));
+			throw new Exception(new Trad('L\'équipement source n\'existe pas', __FILE__));
 		}
 		$targetEq = eqLogic::byId($_targetId);
 		if (!is_object($sourceEq)) {
-			throw new Exception(__('L\'équipement cible n\'existe pas', __FILE__));
+			throw new Exception(new Trad('L\'équipement cible n\'existe pas', __FILE__));
 		}
 
 		$migrateDisplayValues = [
@@ -1354,7 +1354,7 @@ class eqLogic {
 			}
 			return $targetEq;
 		} catch (Exception $e) {
-			throw new Exception(__('Erreur lors de la migration d\'équipement', __FILE__) . ' : ' . log::exception($e));
+			throw new Exception(new Trad('Erreur lors de la migration d\'équipement', __FILE__) . ' : ' . log::exception($e));
 		}
 	}
 
@@ -1584,7 +1584,7 @@ class eqLogic {
 		$_data['node']['eqLogic' . $this->getId()] = array(
 			'id' => 'eqLogic' . $this->getId(),
 			'name' => $this->getName(),
-			'type' => __('Equipement', __FILE__),
+			'type' => new Trad('Equipement', __FILE__),
 			'width' => 60,
 			'height' => 60,
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
@@ -1657,7 +1657,7 @@ class eqLogic {
 					if (!cmd::byId(str_replace('#', '', $cmd_id))) {
 						$return[] = array(
 							'detail' => '<a href="/index.php?v=d&m=' . $eqLogic->getEqType_name() . '&p=' . $eqLogic->getEqType_name() . '&id=' . $eqLogic->getId() . '">' . $eqLogic->getHumanName() . '</a>',
-							'help' => __('Action', __FILE__),
+							'help' => new Trad('Action', __FILE__),
 							'who' => '#' . $cmd_id . '#'
 						);
 					}

--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -71,7 +71,7 @@ class history {
 		if (!is_array($histories)) {
 			$histories = array($histories);
 		}
-		$return = '"' . __('Commande', __FILE__) . '";"' . '"' . __('Date', __FILE__) . '";"' . __('Valeur', __FILE__) . '"' . "\n";
+		$return = '"' . new Trad('Commande', __FILE__) . '";"' . '"' . new Trad('Date', __FILE__) . '";"' . new Trad('Valeur', __FILE__) . '"' . "\n";
 		foreach ($histories as $history) {
 			$return .=  '"' . $history->getCmd()->getHumanName() . '";"' . '"' . $history->getDatetime() . '";"' . $history->getValue() . '"' . "\n";
 		}
@@ -81,23 +81,23 @@ class history {
 	public static function copyHistoryToCmd($_source_id, $_target_id) {
 		$source_cmd = cmd::byId(str_replace('#', '', $_source_id));
 		if (!is_object($source_cmd)) {
-			throw new Exception(__('La commande source n\'existe pas :', __FILE__) . ' ' . $_source_id);
+			throw new Exception(new Trad('La commande source n\'existe pas :', __FILE__) . ' ' . $_source_id);
 		}
 		if ($source_cmd->getIsHistorized() != 1) {
-			throw new Exception(__('La commande source n\'est pas historisée', __FILE__));
+			throw new Exception(new Trad('La commande source n\'est pas historisée', __FILE__));
 		}
 		if ($source_cmd->getType() != 'info') {
-			throw new Exception(__('La commande source n\'est pas de type info', __FILE__));
+			throw new Exception(new Trad('La commande source n\'est pas de type info', __FILE__));
 		}
 		$target_cmd = cmd::byId(str_replace('#', '', $_target_id));
 		if (!is_object($target_cmd)) {
-			throw new Exception(__('La commande cible n\'existe pas :', __FILE__) . ' ' . $_target_id);
+			throw new Exception(new Trad('La commande cible n\'existe pas :', __FILE__) . ' ' . $_target_id);
 		}
 		if ($target_cmd->getType() != 'info') {
-			throw new Exception(__('La commande cible n\'est pas de type info', __FILE__));
+			throw new Exception(new Trad('La commande cible n\'est pas de type info', __FILE__));
 		}
 		if ($target_cmd->getSubType() != $source_cmd->getSubType()) {
-			throw new Exception(__('Le sous-type de la commande cible n\'est pas le même que celui de la commande source', __FILE__));
+			throw new Exception(new Trad('Le sous-type de la commande cible n\'est pas le même que celui de la commande source', __FILE__));
 		}
 		if ($target_cmd->getIsHistorized() != 1) {
 			$target_cmd->setIsHistorized(1);
@@ -341,7 +341,7 @@ class history {
 				try {
 					DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW);
 				} catch (Exception $e) {
-					log::add('history', 'error', __('Erreur l\'archivage des historiques :', __FILE__) . ' ' . json_encode($values) . '  => ' . log::exception($e));
+					log::add('history', 'error', new Trad('Erreur l\'archivage des historiques :', __FILE__) . ' ' . json_encode($values) . '  => ' . log::exception($e));
 					continue;
 				}
 				$values = array('cmd_id' => $sensors['cmd_id'], 'archiveTime' => $archiveDatetime);
@@ -731,7 +731,7 @@ class history {
 	public static function stateDuration($_cmd_id, $_value = null) {
 		$cmd = cmd::byId($_cmd_id);
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
 		}
 		if ($cmd->getIsHistorized() != 1) {
 			return -2;
@@ -756,7 +756,7 @@ class history {
 	public static function lastStateDuration($_cmd_id, $_value = null) {
 		$cmd = cmd::byId($_cmd_id);
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
 		}
 		if ($cmd->getIsHistorized() != 1) {
 			return -2;
@@ -815,7 +815,7 @@ class history {
 	public static function lastChangeStateDuration($_cmd_id, $_value) {
 		$cmd = cmd::byId($_cmd_id);
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
 		}
 		if ($cmd->getIsHistorized() != 1) {
 			return -2;
@@ -879,7 +879,7 @@ class history {
 	public static function stateChanges($_cmd_id, $_value = null, $_startTime = null, $_endTime = null) {
 		$cmd = cmd::byId($_cmd_id);
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . $_cmd_id);
 		}
 		if ($_value === null) {
 			$_value = $cmd->execCmd();

--- a/core/class/interactDef.class.php
+++ b/core/class/interactDef.class.php
@@ -394,7 +394,7 @@ class interactDef {
 
 	public function save() {
 		if ($this->getQuery() == '') {
-			throw new Exception(__('La commande (demande) ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('La commande (demande) ne peut pas être vide', __FILE__));
 		}
 		DB::save($this);
 		return true;
@@ -615,7 +615,7 @@ class interactDef {
 		$icon = findCodeIcon('fa-comments-o');
 		$_data['node']['interactDef' . $this->getId()] = array(
 			'id' => 'interactDef' . $this->getId(),
-			'type' => __('Intéraction', __FILE__),
+			'type' => new Trad('Intéraction', __FILE__),
 			'name' => substr($this->getHumanName(), 0, 20),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],

--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -130,7 +130,7 @@ class interactQuery {
 		if (is_object($query)) {
 			$interactDef = $query->getInteractDef();
 			if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-				log::add('interact', 'debug', __('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . __('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
+				log::add('interact', 'debug', new Trad('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . new Trad('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
 				return null;
 			}
 			log::add('interact', 'debug', 'Je prends : ' . $query->getQuery());
@@ -150,7 +150,7 @@ class interactQuery {
 			if (is_object($query)) {
 				$interactDef = $query->getInteractDef();
 				if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-					log::add('interact', 'debug', __('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . __('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
+					log::add('interact', 'debug', new Trad('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . new Trad('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
 					return null;
 				}
 				return $queries;
@@ -173,7 +173,7 @@ class interactQuery {
 			$lev = levenshtein($input, $_query);
 			$interactDef = $query->getInteractDef();
 			if ($interactDef->getOptions('mustcontain') != '' && !preg_match($interactDef->getOptions('mustcontain'), $_query)) {
-				log::add('interact', 'debug', __('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . __('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
+				log::add('interact', 'debug', new Trad('Correspondance trouvée :', __FILE__) . ' ' . $query->getQuery() . ' ' . new Trad('mais ne contient pas :', __FILE__) . ' ' . interactDef::sanitizeQuery($interactDef->getOptions('mustcontain')));
 				continue;
 			}
 			log::add('interact', 'debug', 'Je compare : ' . $_query . ' avec ' . $input . ' => ' . $lev);
@@ -193,7 +193,7 @@ class interactQuery {
 			}
 		}
 		if ($shortest < 0) {
-			log::add('interact', 'debug', __('Aucune correspondance trouvée', __FILE__));
+			log::add('interact', 'debug', new Trad('Aucune correspondance trouvée', __FILE__));
 			return null;
 		}
 		$weigh = array(1 => config::byKey('interact::weigh1'), 2 => config::byKey('interact::weigh2'), 3 => config::byKey('interact::weigh3'), 4 => config::byKey('interact::weigh4'));
@@ -203,23 +203,23 @@ class interactQuery {
 			}
 		}
 		if (str_word_count($_query) == 1 && config::byKey('interact::confidence1') > 0 && $shortest > config::byKey('interact::confidence1')) {
-			log::add('interact', 'debug', __('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
+			log::add('interact', 'debug', new Trad('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
 			return null;
 		} else if (str_word_count($_query) == 2 && config::byKey('interact::confidence2') > 0 && $shortest > config::byKey('interact::confidence2')) {
-			log::add('interact', 'debug', __('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
+			log::add('interact', 'debug', new Trad('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
 			return null;
 		} else if (str_word_count($_query) == 3 && config::byKey('interact::confidence3') > 0 && $shortest > config::byKey('interact::confidence3')) {
-			log::add('interact', 'debug', __('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
+			log::add('interact', 'debug', new Trad('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
 			return null;
 		} else if (str_word_count($_query) > 3 && config::byKey('interact::confidence') > 0 && $shortest > config::byKey('interact::confidence')) {
-			log::add('interact', 'debug', __('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
+			log::add('interact', 'debug', new Trad('Correspondance trop éloigné :', __FILE__) . ' ' . $shortest);
 			return null;
 		}
 		if (!is_object($closest)) {
-			log::add('interact', 'debug', __('Aucune phrase trouvée', __FILE__));
+			log::add('interact', 'debug', new Trad('Aucune phrase trouvée', __FILE__));
 			return null;
 		}
-		log::add('interact', 'debug', __('J\'ai une correspondance  :', __FILE__) . ' ' . $closest->getQuery() . ' ' . __('avec', __FILE__) . ' ' . $shortest);
+		log::add('interact', 'debug', new Trad('J\'ai une correspondance  :', __FILE__) . ' ' . $closest->getQuery() . ' ' . new Trad('avec', __FILE__) . ' ' . $shortest);
 		return $closest;
 	}
 
@@ -389,7 +389,7 @@ class interactQuery {
 				}
 			}
 			$data['cmd']->execCmd($data['cmd_parameters']);
-			$return = __('C\'est fait', __FILE__) . ' (';
+			$return = new Trad('C\'est fait', __FILE__) . ' (';
 			$eqLogic = $data['cmd']->getEqLogic();
 			if (is_object($eqLogic)) {
 				$object = $eqLogic->getObject();
@@ -432,7 +432,7 @@ class interactQuery {
 				}
 			}
 		} catch (Exception $e) {
-			return array('reply' => __('Erreur :', __FILE__) . ' ' . log::exception($e));
+			return array('reply' => new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		}
 		return null;
 	}
@@ -477,7 +477,7 @@ class interactQuery {
 			$listener->addEvent($data['cmd']->getId());
 			$listener->setOption($options);
 			$listener->save(true);
-			return array('reply' => __('C\'est noté :', __FILE__) . ' ' . str_replace('#value#', $data['cmd']->getHumanName(), $test));
+			return array('reply' => new Trad('C\'est noté :', __FILE__) . ' ' . str_replace('#value#', $data['cmd']->getHumanName(), $test));
 		}
 		return null;
 	}
@@ -496,8 +496,8 @@ class interactQuery {
 				return;
 			}
 			$cmd->execCmd(array(
-				'title' => __('Alerte :', __FILE__) . ' ' . str_replace('#value#', $_options['name'], $_options['test']) . ' ' . __('valeur :', __FILE__) . ' ' . $_options['value'],
-				'message' => __('Alerte :', __FILE__) . ' ' . str_replace('#value#', $_options['name'], $_options['test']) . ' ' . __('valeur :', __FILE__) . ' ' . $_options['value'],
+				'title' => new Trad('Alerte :', __FILE__) . ' ' . str_replace('#value#', $_options['name'], $_options['test']) . ' ' . new Trad('valeur :', __FILE__) . ' ' . $_options['value'],
+				'message' => new Trad('Alerte :', __FILE__) . ' ' . str_replace('#value#', $_options['name'], $_options['test']) . ' ' . new Trad('valeur :', __FILE__) . ' ' . $_options['value'],
 			));
 		}
 	}
@@ -701,14 +701,14 @@ class interactQuery {
 
 	public static function dontUnderstand($_parameters) {
 		$notUnderstood = array(
-			__('Désolé je n\'ai pas compris', __FILE__),
-			__('Désolé je n\'ai pas compris la demande', __FILE__),
-			__('Désolé je ne comprends pas la demande', __FILE__),
-			__('Je ne comprends pas', __FILE__),
+			new Trad('Désolé je n\'ai pas compris', __FILE__),
+			new Trad('Désolé je n\'ai pas compris la demande', __FILE__),
+			new Trad('Désolé je ne comprends pas la demande', __FILE__),
+			new Trad('Je ne comprends pas', __FILE__),
 		);
 		if (isset($_parameters['profile'])) {
-			$notUnderstood[] = __('Désolé', __FILE__) . ' ' . $_parameters['profile'] . ' ' . __('je n\'ai pas compris', __FILE__);
-			$notUnderstood[] = __('Désolé', __FILE__) . ' ' . $_parameters['profile'] . ' ' . __('je n\'ai pas compris ta demande', __FILE__);
+			$notUnderstood[] = new Trad('Désolé', __FILE__) . ' ' . $_parameters['profile'] . ' ' . new Trad('je n\'ai pas compris', __FILE__);
+			$notUnderstood[] = new Trad('Désolé', __FILE__) . ' ' . $_parameters['profile'] . ' ' . new Trad('je n\'ai pas compris ta demande', __FILE__);
 		}
 		$random = rand(0, count($notUnderstood) - 1);
 		return $notUnderstood[$random];
@@ -716,10 +716,10 @@ class interactQuery {
 
 	public static function replyOk() {
 		$reply = array(
-			__('C\'est fait', __FILE__),
-			__('Ok', __FILE__),
-			__('Voilà, c\'est fait', __FILE__),
-			__('Bien compris', __FILE__),
+			new Trad('C\'est fait', __FILE__),
+			new Trad('Ok', __FILE__),
+			new Trad('Voilà, c\'est fait', __FILE__),
+			new Trad('Bien compris', __FILE__),
 		);
 		$random = rand(0, count($reply) - 1);
 		return $reply[$random];
@@ -738,10 +738,10 @@ class interactQuery {
 
 	public function save() {
 		if ($this->getQuery() == '') {
-			throw new Exception(__('La commande vocale ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('La commande vocale ne peut pas être vide', __FILE__));
 		}
 		if ($this->getInteractDef_id() == '') {
-			throw new Exception(__('InteractDef_id ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('InteractDef_id ne peut pas être vide', __FILE__));
 		}
 		DB::save($this);
 		return true;
@@ -757,13 +757,13 @@ class interactQuery {
 		}
 		$interactDef = interactDef::byId($this->getInteractDef_id());
 		if (!is_object($interactDef)) {
-			return __('Inconsistance de la base de données', __FILE__);
+			return new Trad('Inconsistance de la base de données', __FILE__);
 		}
 		if (isset($_parameters['profile']) && trim($interactDef->getPerson()) != '') {
 			$person = strtolower($interactDef->getPerson());
 			$person = explode('|', $person);
 			if (!in_array($_parameters['profile'], $person)) {
-				return __('Vous n\'êtes pas autorisé à exécuter cette action', __FILE__);
+				return new Trad('Vous n\'êtes pas autorisé à exécuter cette action', __FILE__);
 			}
 		}
 		$reply = $interactDef->selectReply();
@@ -808,7 +808,7 @@ class interactQuery {
 		}
 		if ($executeDate !== null && !isset($_parameters['execNow'])) {
 			if (date('Y', $executeDate) < 2000) {
-				return __('Erreur : impossible de calculer la date de programmation', __FILE__);
+				return new Trad('Erreur : impossible de calculer la date de programmation', __FILE__);
 			}
 			if ($executeDate < (strtotime('now') + 60)) {
 				$executeDate = strtotime('now') + 60;
@@ -878,9 +878,9 @@ class interactQuery {
 						$replace['#valeur#'] .= ' ' . $return;
 					}
 				} catch (Exception $e) {
-					log::add('interact', 'error', __('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . __('Détails :', __FILE__) . ' ' . log::exception($e));
+					log::add('interact', 'error', new Trad('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . new Trad('Détails :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add('interact', 'error', __('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . __('Détails :', __FILE__) . ' ' . log::exception($e));
+					log::add('interact', 'error', new Trad('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . new Trad('Détails :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -903,7 +903,7 @@ class interactQuery {
 			}
 		}
 		if ($replace['#valeur#'] == '') {
-			$replace['#valeur#'] = __('aucune valeur', __FILE__);
+			$replace['#valeur#'] = new Trad('aucune valeur', __FILE__);
 		}
 		$replace['"'] = '';
 		return str_replace(array_keys($replace), $replace, $reply);

--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -219,7 +219,7 @@ class jeeObject {
 	public static function getUISelectList($_none = true) {
 		$allObject = self::buildTree(null, false);
 		$options = '';
-		if ($_none) $options .= '<option value="">' . __('Aucun', __FILE__) . '</option>';
+		if ($_none) $options .= '<option value="">' . new Trad('Aucun', __FILE__) . '</option>';
 		foreach ($allObject as $object) {
 			$decay = $object->getConfiguration('parentNumber');
 			$options .= '<option value="' . $object->getId() . '">' . str_repeat('&nbsp;&nbsp;', $decay) . $object->getName() . '</option>';
@@ -582,16 +582,16 @@ class jeeObject {
 			$plugin->setIsEnable(1);
 		}
 		if (!is_object($plugin)) {
-			throw new Exception(__('Le plugin virtuel doit être installé', __FILE__));
+			throw new Exception(new Trad('Le plugin virtuel doit être installé', __FILE__));
 		}
 		if (!$plugin->isActive()) {
-			throw new Exception(__('Le plugin virtuel doit être actif', __FILE__));
+			throw new Exception(new Trad('Le plugin virtuel doit être actif', __FILE__));
 		}
 
 		$virtualGlobal = eqLogic::byLogicalId('summaryglobal', 'virtual');
 		if (!is_object($virtualGlobal)) {
 			$virtualGlobal = new virtual();
-			$virtualGlobal->setName(__('Résumé Global', __FILE__));
+			$virtualGlobal->setName(new Trad('Résumé Global', __FILE__));
 			$virtualGlobal->setIsVisible(0);
 			$virtualGlobal->setIsEnable(1);
 		}
@@ -628,7 +628,7 @@ class jeeObject {
 			$virtual = eqLogic::byLogicalId('summary' . $object->getId(), 'virtual');
 			if (!is_object($virtual)) {
 				$virtual = new virtual();
-				$virtual->setName(__('Résumé', __FILE__));
+				$virtual->setName(new Trad('Résumé', __FILE__));
 				$virtual->setIsVisible(0);
 				$virtual->setIsEnable(1);
 			}
@@ -720,7 +720,7 @@ class jeeObject {
 		} else {
 			$object = self::byId($_cmd->getConfiguration('summary::object_id'));
 			if (!is_object($object)) {
-				throw new Exception(__('L\'objet n\'existe pas :', __FILE__) . ' ' . $_cmd->getConfiguration('summary::object_id'));
+				throw new Exception(new Trad('L\'objet n\'existe pas :', __FILE__) . ' ' . $_cmd->getConfiguration('summary::object_id'));
 			}
 			$object->summaryAction($_cmd, $_options);
 		}
@@ -787,7 +787,7 @@ class jeeObject {
 			return;
 		}
 		if (in_array($this->getFather_id(), $_fathers)) {
-			throw new Exception(__('Problème dans l\'arbre des objets', __FILE__));
+			throw new Exception(new Trad('Problème dans l\'arbre des objets', __FILE__));
 		}
 		$_fathers[] = $this->getId();
 
@@ -796,7 +796,7 @@ class jeeObject {
 
 	public function preSave() {
 		if (is_numeric($this->getFather_id()) && $this->getFather_id() == $this->getId()) {
-			throw new Exception(__('L\'objet ne peut pas être son propre parent', __FILE__));
+			throw new Exception(new Trad('L\'objet ne peut pas être son propre parent', __FILE__));
 		}
 
 		$this->checkTreeConsistency();
@@ -1196,7 +1196,7 @@ class jeeObject {
 		$icon = findCodeIcon($this->getDisplay('icon'));
 		$_data['node']['object' . $this->getId()] = array(
 			'id' => 'object' . $this->getId(),
-			'type' => __('Objet', __FILE__),
+			'type' => new Trad('Objet', __FILE__),
 			'name' => $this->getName(),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],

--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -157,7 +157,7 @@ class jeedom {
 		$cmd = config::byKey('interact::warnme::defaultreturncmd', 'core', '');
 		if ($cmd != '') {
 			if (!cmd::byId(str_replace('#', '', $cmd))) {
-				$return[] = array('detail' => __('Administration', __FILE__), 'help' => __('Commande retour interactions', __FILE__), 'who' => $cmd);
+				$return[] = array('detail' => new Trad('Administration', __FILE__), 'help' => new Trad('Commande retour interactions', __FILE__), 'who' => $cmd);
 			}
 		}
 		foreach ($JEEDOM_INTERNAL_CONFIG['alerts'] as $level => $value) {
@@ -165,7 +165,7 @@ class jeedom {
 			preg_match_all("/#([0-9]*)#/", $cmds, $matches);
 			foreach ($matches[1] as $cmd_id) {
 				if (!cmd::byId($cmd_id)) {
-					$return[] = array('detail' => __('Administration', __FILE__), 'help' => __('Commande sur', __FILE__) . ' ' . $value['name'], 'who' => '#' . $cmd_id . '#');
+					$return[] = array('detail' => new Trad('Administration', __FILE__), 'help' => new Trad('Commande sur', __FILE__) . ' ' . $value['name'], 'who' => '#' . $cmd_id . '#');
 				}
 			}
 		}
@@ -175,7 +175,7 @@ class jeedom {
 	public static function health() {
 		$return = array();
 		$return[] = array(
-			'name' => __('Matériel', __FILE__),
+			'name' => new Trad('Matériel', __FILE__),
 			'state' => true,
 			'result' => jeedom::getHardwareName(),
 			'comment' => '',
@@ -185,36 +185,36 @@ class jeedom {
 		$nbNeedUpdate = update::nbNeedUpdate();
 		$state = ($nbNeedUpdate == 0) ? true : false;
 		$return[] = array(
-			'name' => __('Système à jour', __FILE__),
+			'name' => new Trad('Système à jour', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) : $nbNeedUpdate,
+			'result' => ($state) ? new Trad('OK', __FILE__) : $nbNeedUpdate,
 			'comment' => '',
 			'key' => 'uptodate'
 		);
 
 		$state = (config::byKey('enableCron', 'core', 1, true) != 0) ? true : false;
 		$return[] = array(
-			'name' => __('Cron actif', __FILE__),
+			'name' => new Trad('Cron actif', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-			'comment' => ($state) ? '' : __('Erreur cron : les crons sont désactivés. Allez dans Réglages -> Système -> Moteur de tâches pour les réactiver', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Erreur cron : les crons sont désactivés. Allez dans Réglages -> Système -> Moteur de tâches pour les réactiver', __FILE__),
 			'key' => 'cron::enable'
 		);
 
 		$state = (config::byKey('enableScenario') == 0 && count(scenario::all()) > 0) ? false : true;
 		$return[] = array(
-			'name' => __('Scénario actif', __FILE__),
+			'name' => new Trad('Scénario actif', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-			'comment' => ($state) ? '' : __('Erreur scénario : tous les scénarios sont désactivés. Allez dans Outils -> Scénarios pour les réactiver', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Erreur scénario : tous les scénarios sont désactivés. Allez dans Outils -> Scénarios pour les réactiver', __FILE__),
 			'key' => 'scenario::enable'
 		);
 
 		$state = self::isStarted();
 		$return[] = array(
-			'name' => __('Démarré', __FILE__),
+			'name' => new Trad('Démarré', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) . ' ' . file_get_contents(self::getTmpFolder() . '/started') : __('NOK', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) . ' ' . file_get_contents(self::getTmpFolder() . '/started') : new Trad('NOK', __FILE__),
 			'comment' => '',
 			'key' => 'isStarted'
 		);
@@ -226,26 +226,26 @@ class jeedom {
 			$lastKnowDate = 0;
 		}
 		$return[] = array(
-			'name' => __('Date système (dernière heure enregistrée)', __FILE__),
+			'name' => new Trad('Date système (dernière heure enregistrée)', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) . ' ' . date('Y-m-d H:i:s') . ' (' . gmdate('Y-m-d H:i:s', $lastKnowDate) . ')' : date('Y-m-d H:i:s'),
-			'comment' => ($state) ? '' : __('Si la dernière heure enregistrée est fausse, il faut la remettre à zéro', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) . ' ' . date('Y-m-d H:i:s') . ' (' . gmdate('Y-m-d H:i:s', $lastKnowDate) . ')' : date('Y-m-d H:i:s'),
+			'comment' => ($state) ? '' : new Trad('Si la dernière heure enregistrée est fausse, il faut la remettre à zéro', __FILE__),
 			'key' => 'hour'
 		);
 
 		$state = self::isCapable('sudo', true);
 		$return[] = array(
-			'name' => __('Droits sudo', __FILE__),
+			'name' => new Trad('Droits sudo', __FILE__),
 			'state' => ($state) ? 1 : 2,
-			'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-			'comment' => ($state) ? '' : __('Appliquez les droits root à Jeedom', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Appliquez les droits root à Jeedom', __FILE__),
 			'key' => 'sudo::right'
 		);
 
 		$mbState = config::byKey('mbState');
 		if ($mbState == 0) {
 			$return[] = array(
-				'name' => __('Version Jeedom', __FILE__),
+				'name' => new Trad('Version Jeedom', __FILE__),
 				'state' => true,
 				'result' => self::version(),
 				'comment' => '',
@@ -253,7 +253,7 @@ class jeedom {
 			);
 		} else {
 			$return[] = array(
-				'name' => __('Version', __FILE__),
+				'name' => new Trad('Version', __FILE__),
 				'state' => true,
 				'result' => self::version(),
 				'comment' => '',
@@ -262,7 +262,7 @@ class jeedom {
 		}
 
 		$return[] = array(
-			'name' => __('Version OS', __FILE__),
+			'name' => new Trad('Version OS', __FILE__),
 			'state' => (system::getDistrib() == 'debian' && version_compare(system::getOsVersion(), config::byKey('os::min'), '>=')),
 			'result' => system::getDistrib() . ' ' . system::getOsVersion(),
 			'comment' => '',
@@ -271,16 +271,16 @@ class jeedom {
 
 		$state = version_compare(phpversion(), '5.5', '>=');
 		$return[] = array(
-			'name' => __('Version PHP', __FILE__),
+			'name' => new Trad('Version PHP', __FILE__),
 			'state' => $state,
 			'result' => phpversion(),
-			'comment' => ($state) ? '' : __('Si vous êtes en version 5.4.x on vous indiquera quand la version 5.5 sera obligatoire', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Si vous êtes en version 5.4.x on vous indiquera quand la version 5.5 sera obligatoire', __FILE__),
 			'key' => 'php::version'
 		);
 
 		$apaches = count(system::ps('apache2'));
 		$return[] = array(
-			'name' => __('Nombre de processus Apache', __FILE__),
+			'name' => new Trad('Nombre de processus Apache', __FILE__),
 			'state' => ($apaches > 0),
 			'result' => $apaches,
 			'comment' => '',
@@ -301,15 +301,15 @@ class jeedom {
 			}
 		}
 		$return[] = array(
-			'name' => __('Version OS', __FILE__),
+			'name' => new Trad('Version OS', __FILE__),
 			'state' => $state,
 			'result' => ($state) ? $uname . ' [' . $version . ']' : $uname,
-			'comment' => ($state) ? '' : __('Vous n\'êtes pas sur un OS officiellement supporté par l\'équipe Jeedom (toute demande de support pourra donc être refusée). Les OS officiellement supportés sont Debian Strech et Debian Buster', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Vous n\'êtes pas sur un OS officiellement supporté par l\'équipe Jeedom (toute demande de support pourra donc être refusée). Les OS officiellement supportés sont Debian Strech et Debian Buster', __FILE__),
 		);
 
 		$version = DB::Prepare('select version()', array(), DB::FETCH_TYPE_ROW);
 		$return[] = array(
-			'name' => __('Version database', __FILE__),
+			'name' => new Trad('Version database', __FILE__),
 			'state' => true,
 			'result' => $version['version()'],
 			'comment' => '',
@@ -318,7 +318,7 @@ class jeedom {
 
 		$value = self::checkSpaceLeft();
 		$return[] = array(
-			'name' => __('Espace disque libre', __FILE__),
+			'name' => new Trad('Espace disque libre', __FILE__),
 			'state' => ($value > 10),
 			'result' => $value . ' %',
 			'comment' => '',
@@ -329,7 +329,7 @@ class jeedom {
 		$max_used_connection = DB::Prepare('SHOW STATUS WHERE `variable_name` = \'Max_used_connections\';', array(), DB::FETCH_TYPE_ROW);
 		$allow_connection = DB::Prepare('SHOW VARIABLES LIKE \'max_connections\'', array(), DB::FETCH_TYPE_ROW);
 		$return[] = array(
-			'name' => __('Connexion active/max/autorisée', __FILE__),
+			'name' => new Trad('Connexion active/max/autorisée', __FILE__),
 			'state' => true,
 			'result' => $nb_active_connection['Value'] . '/' . $max_used_connection['Value'] . '/' . $allow_connection['Value'],
 			'comment' => '',
@@ -338,7 +338,7 @@ class jeedom {
 
 		$size = DB::Prepare('SELECT SUM(data_length + index_length) as size FROM information_schema.tables WHERE table_schema = \'jeedom\' GROUP BY table_schema;', array(), DB::FETCH_TYPE_ROW);
 		$return[] = array(
-			'name' => __('Taille base de données', __FILE__),
+			'name' => new Trad('Taille base de données', __FILE__),
 			'state' => true,
 			'result' => sizeFormat($size['size']),
 			'comment' => '',
@@ -347,28 +347,28 @@ class jeedom {
 
 		$value = self::checkSpaceLeft(self::getTmpFolder());
 		$return[] = array(
-			'name' => __('Espace disque libre tmp', __FILE__),
+			'name' => new Trad('Espace disque libre tmp', __FILE__),
 			'state' => ($value > 10),
 			'result' => $value . ' %',
-			'comment' => ($value > 10) ? '' : __('En cas d\'erreur essayez de redémarrer. Si le problème persiste, testez en désactivant les plugins un à un jusqu\'à trouver le coupable', __FILE__),
+			'comment' => ($value > 10) ? '' : new Trad('En cas d\'erreur essayez de redémarrer. Si le problème persiste, testez en désactivant les plugins un à un jusqu\'à trouver le coupable', __FILE__),
 			'key' => 'space::tmp'
 		);
 
 		$values = getSystemMemInfo();
 		$value = round(($values['MemAvailable'] / $values['MemTotal']) * 100);
 		$return[] = array(
-			'name' => __('Mémoire disponible', __FILE__),
+			'name' => new Trad('Mémoire disponible', __FILE__),
 			'state' => ($value > 15),
-			'result' => $value . ' % (' . __('Total', __FILE__) . ' ' . round($values['MemTotal'] / 1024) . ' Mo)',
+			'result' => $value . ' % (' . new Trad('Total', __FILE__) . ' ' . round($values['MemTotal'] / 1024) . ' Mo)',
 			'comment' => '',
 		);
 
 		$value = shell_exec('sudo dmesg | grep oom-killer | grep -v deprecated | wc -l');
 		$return[] = array(
-			'name' => __('Mémoire suffisante', __FILE__),
+			'name' => new Trad('Mémoire suffisante', __FILE__),
 			'state' => ($value == 0),
 			'result' => $value,
-			'comment' => ($value == 0) ? '' : __('Nombre de processus tués par le noyau pour manque de mémoire. Votre système manque de mémoire. Essayez de réduire le nombre de plugins ou de scénarios', __FILE__),
+			'comment' => ($value == 0) ? '' : new Trad('Nombre de processus tués par le noyau pour manque de mémoire. Votre système manque de mémoire. Essayez de réduire le nombre de plugins ou de scénarios', __FILE__),
 		);
 
 		$value = shell_exec('sudo dmesg | grep "CRC error" | grep "mmcblk0" | grep "card status" | wc -l');
@@ -380,10 +380,10 @@ class jeedom {
 			$value += $value2;
 		}
 		$return[] = array(
-			'name' => __('Erreur I/O', __FILE__),
+			'name' => new Trad('Erreur I/O', __FILE__),
 			'state' => ($value == 0),
 			'result' => $value,
-			'comment' => ($value == 0) ? '' : __('Il y a des erreurs disque, cela peut indiquer un soucis avec le disque ou un problème d\'alimentation', __FILE__),
+			'comment' => ($value == 0) ? '' : new Trad('Il y a des erreurs disque, cela peut indiquer un soucis avec le disque ou un problème d\'alimentation', __FILE__),
 			'key' => 'io_error'
 		);
 
@@ -394,17 +394,17 @@ class jeedom {
 				$ok = false;
 			}
 			$return[] = array(
-				'name' => __('Swap disponible', __FILE__),
+				'name' => new Trad('Swap disponible', __FILE__),
 				'state' => $ok,
-				'result' => $value . ' % (' . __('Total', __FILE__) . ' ' . round($values['SwapTotal'] / 1024) . ' Mo)',
-				'comment' => ($ok) ? '' : __('Le swap libre n\'est pas suffisant ou il y a moins de 2Go de mémoire sur le système et un swap inférieure à 1Go', __FILE__),
+				'result' => $value . ' % (' . new Trad('Total', __FILE__) . ' ' . round($values['SwapTotal'] / 1024) . ' Mo)',
+				'comment' => ($ok) ? '' : new Trad('Le swap libre n\'est pas suffisant ou il y a moins de 2Go de mémoire sur le système et un swap inférieure à 1Go', __FILE__),
 				'key' => 'swap'
 			);
 		} else {
 			$return[] = array(
-				'name' => __('Swap disponible', __FILE__),
+				'name' => new Trad('Swap disponible', __FILE__),
 				'state' => 2,
-				'result' => __('Inconnue', __FILE__),
+				'result' => new Trad('Inconnue', __FILE__),
 				'comment' => '',
 				'key' => 'swap'
 			);
@@ -416,16 +416,16 @@ class jeedom {
 			$ok = true;
 		}
 		$return[] = array(
-			'name' => __('Swappiness', __FILE__),
+			'name' => new Trad('Swappiness', __FILE__),
 			'state' => $ok,
 			'result' => $value . '%',
-			'comment' => ($ok) ? '' : __('Pour des performances optimales le swapiness ne doit pas dépasser 20% si vous avez 1Go ou moins de mémoire', __FILE__),
+			'comment' => ($ok) ? '' : new Trad('Pour des performances optimales le swapiness ne doit pas dépasser 20% si vous avez 1Go ou moins de mémoire', __FILE__),
 			'key' => 'swapiness'
 		);
 
 		$values = sys_getloadavg();
 		$return[] = array(
-			'name' => __('Charge', __FILE__),
+			'name' => new Trad('Charge', __FILE__),
 			'state' => ($values[2] < 20),
 			'result' => round($values[0],2) . ' - ' . round($values[1],2) . ' - ' . round($values[2],2),
 			'comment' => '',
@@ -434,25 +434,25 @@ class jeedom {
 
 		$state = network::test('internal');
 		$return[] = array(
-			'name' => __('Configuration réseau interne', __FILE__),
+			'name' => new Trad('Configuration réseau interne', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-			'comment' => ($state) ? '' : __('Allez sur Réglages -> Système -> Configuration -> onglet Réseaux, puis configurez correctement la partie réseau', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Allez sur Réglages -> Système -> Configuration -> onglet Réseaux, puis configurez correctement la partie réseau', __FILE__),
 			'key' => 'network::internal'
 		);
 
 		$state = network::test('external');
 		$return[] = array(
-			'name' => __('Configuration réseau externe', __FILE__),
+			'name' => new Trad('Configuration réseau externe', __FILE__),
 			'state' => $state,
-			'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-			'comment' => ($state) ? '' : __('Allez sur Réglages -> Système -> Configuration -> onglet Réseaux, puis configurez correctement la partie réseau', __FILE__),
+			'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+			'comment' => ($state) ? '' : new Trad('Allez sur Réglages -> Système -> Configuration -> onglet Réseaux, puis configurez correctement la partie réseau', __FILE__),
 			'key' => 'network::external'
 		);
 
 		$value = shell_exec('node --version');
 		$return[] = array(
-			'name' => __('Node', __FILE__),
+			'name' => new Trad('Node', __FILE__),
 			'state' => true,
 			'result' => $value,
 			'comment' => '',
@@ -462,7 +462,7 @@ class jeedom {
 		if (shell_exec('which python') != '') {
 			$value = shell_exec('python --version 2>&1'); // prior python 3.4, 'python --version' output was on stderr
 			$return[] = array(
-				'name' => __('Python', __FILE__),
+				'name' => new Trad('Python', __FILE__),
 				'state' => true,
 				'result' => $value,
 				'comment' => '',
@@ -473,7 +473,7 @@ class jeedom {
 		if (shell_exec('which python3') != '') {
 			$value = shell_exec('python3 --version');
 			$return[] = array(
-				'name' => __('Python 3', __FILE__),
+				'name' => new Trad('Python 3', __FILE__),
 				'state' => true,
 				'result' => $value,
 				'comment' => '',
@@ -482,30 +482,30 @@ class jeedom {
 		}
 
 
-		$cache_health = array('comment' => '', 'name' => __('Persistance du cache', __FILE__), 'key' => 'cache::persit');
+		$cache_health = array('comment' => '', 'name' => new Trad('Persistance du cache', __FILE__), 'key' => 'cache::persit');
 		if (cache::isPersistOk()) {
 			if (config::byKey('cache::engine') != 'FilesystemCache' && config::byKey('cache::engine') != 'PhpFileCache') {
 				$cache_health['state'] = true;
-				$cache_health['result'] = __('OK', __FILE__);
+				$cache_health['result'] = new Trad('OK', __FILE__);
 			} else {
 				$filename = __DIR__ . '/../../cache.tar.gz';
 				$cache_health['state'] = true;
-				$cache_health['result'] = __('OK', __FILE__) . ' (' . date('Y-m-d H:i:s', filemtime($filename)) . ')';
+				$cache_health['result'] = new Trad('OK', __FILE__) . ' (' . date('Y-m-d H:i:s', filemtime($filename)) . ')';
 			}
 		} else {
 			$cache_health['state'] = false;
-			$cache_health['result'] = __('NOK', __FILE__);
-			$cache_health['comment'] = __('Votre cache n\'est pas sauvegardé. En cas de redémarrage, certaines informations peuvent être perdues. Essayez de lancer (à partir du moteur de tâches) la tâche cache::persist.', __FILE__);
+			$cache_health['result'] = new Trad('NOK', __FILE__);
+			$cache_health['comment'] = new Trad('Votre cache n\'est pas sauvegardé. En cas de redémarrage, certaines informations peuvent être perdues. Essayez de lancer (à partir du moteur de tâches) la tâche cache::persist.', __FILE__);
 		}
 		$return[] = $cache_health;
 
 		if (jeedom::getHardwareName() != 'docker') {
 			$state = shell_exec('systemctl show apache2 | grep  PrivateTmp | grep yes | wc -l');
 			$return[] = array(
-				'name' => __('Apache private tmp', __FILE__),
+				'name' => new Trad('Apache private tmp', __FILE__),
 				'state' => $state,
-				'result' => ($state) ? __('OK', __FILE__) : __('NOK', __FILE__),
-				'comment' => ($state) ? '' : __('Veuillez désactiver le private tmp d\'Apache (Jeedom ne peut marcher avec).', __FILE__) . '</a>',
+				'result' => ($state) ? new Trad('OK', __FILE__) : new Trad('NOK', __FILE__),
+				'comment' => ($state) ? '' : new Trad('Veuillez désactiver le private tmp d\'Apache (Jeedom ne peut marcher avec).', __FILE__) . '</a>',
 				'key' => 'apache2::privateTmp'
 			);
 		}
@@ -619,7 +619,7 @@ class jeedom {
 			}
 			global $_USER_GLOBAL;
 			$_USER_GLOBAL = $user;
-			log::add('connection', 'info', __('Connexion par API de l\'utilisateur :', __FILE__) . ' ' . $user->getLogin());
+			log::add('connection', 'info', new Trad('Connexion par API de l\'utilisateur :', __FILE__) . ' ' . $user->getLogin());
 			return true;
 		}
 		if (!self::apiModeResult(config::byKey('api::' . $_plugin . '::mode', 'core', 'enable'))) {
@@ -851,7 +851,7 @@ class jeedom {
 		if (file_exists($_backup)) {
 			unlink($_backup);
 		} else {
-			throw new Exception(__('Impossible de trouver le fichier :', __FILE__) . ' ' . $_backup);
+			throw new Exception(new Trad('Impossible de trouver le fichier :', __FILE__) . ' ' . $_backup);
 		}
 	}
 
@@ -1044,7 +1044,7 @@ class jeedom {
 			self::forceSyncHour();
 			sleep(3);
 			if (strtotime('now') < $mindate || strtotime('now') > $maxdate) {
-				log::add('core', 'error', __('La date du système est incorrecte (avant ' . $minDateValue . ' ou après ' . $maxDateValue . ') :', __FILE__) . ' ' . (new \DateTime())->format('Y-m-d H:i:s'), 'dateCheckFailed');
+				log::add('core', 'error', new Trad('La date du système est incorrecte (avant ' . $minDateValue . ' ou après ' . $maxDateValue . ') :', __FILE__) . ' ' . (new \DateTime())->format('Y-m-d H:i:s'), 'dateCheckFailed');
 				return false;
 			}
 		}
@@ -1095,129 +1095,129 @@ class jeedom {
 	public static function cron() {
 		if (!self::isStarted()) {
 			echo date('Y-m-d H:i:s') . ' starting Jeedom';
-			log::add('starting', 'debug', __('Démarrage de jeedom', __FILE__));
+			log::add('starting', 'debug', new Trad('Démarrage de jeedom', __FILE__));
 			try {
-				log::add('starting', 'debug', __('Arrêt des crons', __FILE__));
+				log::add('starting', 'debug', new Trad('Arrêt des crons', __FILE__));
 				foreach ((cron::all()) as $cron) {
 					if ($cron->running() && $cron->getClass() != 'jeedom' && $cron->getFunction() != 'cron') {
 						try {
 							$cron->halt();
 						} catch (Exception $e) {
-							log::add('starting', 'error', __('Erreur sur l\'arrêt d\'une tâche cron :', __FILE__) . ' ' . log::exception($e));
+							log::add('starting', 'error', new Trad('Erreur sur l\'arrêt d\'une tâche cron :', __FILE__) . ' ' . log::exception($e));
 						} catch (Error $e) {
-							log::add('starting', 'error', __('Erreur sur l\'arrêt d\'une tâche cron :', __FILE__) . ' ' . log::exception($e));
+							log::add('starting', 'error', new Trad('Erreur sur l\'arrêt d\'une tâche cron :', __FILE__) . ' ' . log::exception($e));
 						}
 					}
 				}
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur l\'arrêt des tâches crons :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur l\'arrêt des tâches crons :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur l\'arrêt des tâches crons :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur l\'arrêt des tâches crons :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Restauration du cache', __FILE__));
+				log::add('starting', 'debug', new Trad('Restauration du cache', __FILE__));
 				cache::restore();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur la restauration du cache :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la restauration du cache :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur la restauration du cache :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la restauration du cache :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Consolidation de l\'historique', __FILE__));
+				log::add('starting', 'debug', new Trad('Consolidation de l\'historique', __FILE__));
 				history::checkCurrentValueAndHistory();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur la consolidation de l\'historique :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la consolidation de l\'historique :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur la consolidation de l\'historique :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la consolidation de l\'historique :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Nettoyage du cache des péripheriques USB', __FILE__));
+				log::add('starting', 'debug', new Trad('Nettoyage du cache des péripheriques USB', __FILE__));
 				$cache = cache::byKey('jeedom::usbMapping');
 				$cache->remove();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur le nettoyage du cache des péripheriques USB :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le nettoyage du cache des péripheriques USB :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur le nettoyage du cache des péripheriques USB :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le nettoyage du cache des péripheriques USB :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Nettoyage du cache des péripheriques Bluetooth', __FILE__));
+				log::add('starting', 'debug', new Trad('Nettoyage du cache des péripheriques Bluetooth', __FILE__));
 				$cache = cache::byKey('jeedom::bluetoothMapping');
 				$cache->remove();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur le nettoyage du cache des péripheriques Bluetooth :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le nettoyage du cache des péripheriques Bluetooth :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur le nettoyage du cache des péripheriques Bluetooth :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le nettoyage du cache des péripheriques Bluetooth :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Démarrage des processus Internet de Jeedom', __FILE__));
+				log::add('starting', 'debug', new Trad('Démarrage des processus Internet de Jeedom', __FILE__));
 				self::start();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur le démarrage interne de Jeedom :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le démarrage interne de Jeedom :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur le démarrage interne de Jeedom :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le démarrage interne de Jeedom :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Ecriture du fichier', __FILE__) . ' ' . self::getTmpFolder() . '/started');
+				log::add('starting', 'debug', new Trad('Ecriture du fichier', __FILE__) . ' ' . self::getTmpFolder() . '/started');
 				if (file_put_contents(self::getTmpFolder() . '/started', date('Y-m-d H:i:s')) === false) {
-					log::add('starting', 'error', __('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started');
+					log::add('starting', 'error', new Trad('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started');
 				}
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started : ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started : ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started : ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . '/started : ' . log::exception($e));
 			}
 
 			if (!file_exists(self::getTmpFolder() . '/started')) {
-				log::add('starting', 'critical', __('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . __('/started pour une raison inconnue. Jeedom ne peut démarrer', __FILE__));
+				log::add('starting', 'critical', new Trad('Impossible d\'écrire', __FILE__) . ' ' . self::getTmpFolder() . new Trad('/started pour une raison inconnue. Jeedom ne peut démarrer', __FILE__));
 				return;
 			}
 
 			try {
-				log::add('starting', 'debug', __('Vérification de la configuration réseau interne', __FILE__));
+				log::add('starting', 'debug', new Trad('Vérification de la configuration réseau interne', __FILE__));
 				if (!network::test('internal')) {
 					network::checkConf('internal');
 				}
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur la configuration réseau interne :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la configuration réseau interne :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur la configuration réseau interne :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la configuration réseau interne :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Envoi de l\'événement de démarrage', __FILE__));
+				log::add('starting', 'debug', new Trad('Envoi de l\'événement de démarrage', __FILE__));
 				self::event('start');
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur l\'envoi de l\'événement de démarrage :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur l\'envoi de l\'événement de démarrage :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur l\'envoi de l\'événement de démarrage :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur l\'envoi de l\'événement de démarrage :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
-				log::add('starting', 'debug', __('Démarrage des plugins', __FILE__));
+				log::add('starting', 'debug', new Trad('Démarrage des plugins', __FILE__));
 				plugin::start();
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur le démarrage des plugins :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur le démarrage des plugins :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur la démarrage des plugins :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la démarrage des plugins :', __FILE__) . ' ' . log::exception($e));
 			}
 
 			try {
 				if (config::byKey('market::enable') == 1) {
-					log::add('starting', 'debug', __('Test de connexion au market', __FILE__));
+					log::add('starting', 'debug', new Trad('Test de connexion au market', __FILE__));
 					repo_market::test();
 				}
 			} catch (Exception $e) {
-				log::add('starting', 'error', __('Erreur sur la connexion au market :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la connexion au market :', __FILE__) . ' ' . log::exception($e));
 			} catch (Error $e) {
-				log::add('starting', 'error', __('Erreur sur la connexion au market :', __FILE__) . ' ' . log::exception($e));
+				log::add('starting', 'error', new Trad('Erreur sur la connexion au market :', __FILE__) . ' ' . log::exception($e));
 			}
-			log::add('starting', 'debug', __('Démarrage de jeedom fini avec succès', __FILE__));
+			log::add('starting', 'debug', new Trad('Démarrage de jeedom fini avec succès', __FILE__));
 		}
 		self::isDateOk();
 	}
@@ -1253,7 +1253,7 @@ class jeedom {
 		}
 		$disk_space = self::checkSpaceLeft();
 		if($disk_space < 10){
-			log::add('jeedom', 'error',__('Espace disque disponible faible : ',__FILE__).$disk_space.'%.'.__('Veuillez faire de la place (suppression de backup, de video/capture du plugin camera, d\'historique...)',__FILE__));
+			log::add('jeedom', 'error',new Trad('Espace disque disponible faible : ', __FILE__).$disk_space.'%.'.new Trad('Veuillez faire de la place (suppression de backup, de video/capture du plugin camera, d\'historique...)',__FILE__));
 		}
 	}
 
@@ -1286,8 +1286,8 @@ class jeedom {
 					}
 					if ($toUpdate != '') {
 						//set $_logicalId so update function can remove such messages. Bypassed by message::save to notify different updates instead of new occurence.
-						$msg = __('De nouvelles mises à jour sont disponibles', __FILE__) . ' : ' . trim($toUpdate, ',');
-						$action = '<a href="/index.php?v=d&p=update">' . __('Centre de mise à jour', __FILE__) . '</a>';
+						$msg = new Trad('De nouvelles mises à jour sont disponibles', __FILE__) . ' : ' . trim($toUpdate, ',');
+						$action = '<a href="/index.php?v=d&p=update">' . new Trad('Centre de mise à jour', __FILE__) . '</a>';
 						message::add('update', $msg, $action, 'newUpdate');
 					}
 				}
@@ -1697,7 +1697,7 @@ class jeedom {
 		if (self::isCapable('sudo')) {
 			exec(system::getCmdSudo() . 'shutdown -fh now');
 		} else {
-			throw new Exception(__('Vous pouvez arrêter le système', __FILE__));
+			throw new Exception(new Trad('Vous pouvez arrêter le système', __FILE__));
 		}
 	}
 
@@ -1707,7 +1707,7 @@ class jeedom {
 		if (self::isCapable('sudo')) {
 			exec(system::getCmdSudo() . 'shutdown -fr now');
 		} else {
-			throw new Exception(__('Vous pouvez lancer le redémarrage du système', __FILE__));
+			throw new Exception(new Trad('Vous pouvez lancer le redémarrage du système', __FILE__));
 		}
 	}
 

--- a/core/class/jsonrpcClient.class.php
+++ b/core/class/jsonrpcClient.class.php
@@ -140,10 +140,10 @@ class jsonrpcClient {
 			}
 			if(config::byKey('proxyEnabled')) {
 				if(config::byKey('proxyAddress') == ''){ 
-				// throw new Exception(__('renseigne l\'adresse', __FILE__));
+				// throw new Exception(new Trad('renseigne l\'adresse', __FILE__));
 				$this->error = 'Erreur address ';
 			} else if (config::byKey('proxyPort') == ''){
-			// throw new Exception(__('renseigne le port', __FILE__));
+			// throw new Exception(new Trad('renseigne le port', __FILE__));
 			} else {
 				curl_setopt($ch, CURLOPT_PROXY, config::byKey('proxyAddress'));
 				curl_setopt($ch, CURLOPT_PROXYPORT, config::byKey('proxyPort'));

--- a/core/class/listener.class.php
+++ b/core/class/listener.class.php
@@ -262,7 +262,7 @@ class listener {
 				if (class_exists($class) && method_exists($class, $function)) {
 					$class::$function($option);
 				} else {
-					log::add('listener', 'debug', __('[Erreur] Classe ou fonction non trouvée', __FILE__) . ' ' . json_encode(utils::o2a($this)));
+					log::add('listener', 'debug', new Trad('[Erreur] Classe ou fonction non trouvée', __FILE__) . ' ' . json_encode(utils::o2a($this)));
 					$this->remove();
 					return;
 				}
@@ -271,7 +271,7 @@ class listener {
 				if (function_exists($function)) {
 					$function($option);
 				} else {
-					log::add('listener', 'error', __('[Erreur] Fonction non trouvée', __FILE__) . ' ' . json_encode(utils::o2a($this)));
+					log::add('listener', 'error', new Trad('[Erreur] Fonction non trouvée', __FILE__) . ' ' . json_encode(utils::o2a($this)));
 					$this->remove();
 					return;
 				}
@@ -283,7 +283,7 @@ class listener {
 
 	public function preSave() {
 		if ($this->getFunction() == '') {
-			throw new Exception(__('La fonction ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('La fonction ne peut pas être vide', __FILE__));
 		}
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -59,7 +59,12 @@ class log extends AbstractLogger {
 
 	public static function getConfig($_key, $_default = '') {
 		if (self::$config === null) {
-			self::$config = array_merge(config::getLogLevelPlugin(), config::byKeys(array('log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog')));
+			try {
+				self::$config = array_merge(config::getLogLevelPlugin(), config::byKeys(array('log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog')));
+			} catch (Exception $e) {
+				echo $e->getMessage();
+				self::$config = array();
+			}
 		}
 		if (isset(self::$config[$_key])) {
 			return self::$config[$_key];

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -17,7 +17,7 @@
 */
 
 /* * ***************************Includes********************************* */
-require_once __DIR__ . '/../../core/php/core.inc.php';
+// require_once __DIR__ . '/../../core/php/core.inc.php';
 
 use Psr\Log\AbstractLogger;
 
@@ -125,7 +125,7 @@ class log extends AbstractLogger {
 		fwrite($fp,'['.date('Y-m-d H:i:s').']['.strtoupper($_type).'] '.$_message."\n");  
 		fclose($fp);
 		try {
-            $action = '<a href="/index.php?v=d&p=log&logfile=' . $_log . '">' . __('Log', __FILE__) . ' ' . $_log . '</a>';
+            $action = '<a href="/index.php?v=d&p=log&logfile=' . $_log . '">' . 'Log ' . $_log . '</a>';
 			if ($level == 400 && self::getConfig('addMessageForErrorLog') == 1) {
 				@message::add($_log, $_message, $action, $_logicalId);
 			} elseif ($level >= 500 && $_log != 'update') {

--- a/core/class/message.class.php
+++ b/core/class/message.class.php
@@ -219,7 +219,7 @@ class message {
 					scenarioExpression::createAndExec('action', $action['cmd'], $options);
 				}
 			}
-			event::add('notify', array('title' => __('Message de', __FILE__) . ' ' . ' ' . $this->getPlugin(), 'message' => $this->getMessage(true), 'category' => 'message'));
+			event::add('notify', array('title' => new Trad('Message de', __FILE__) . ' ' . ' ' . $this->getPlugin(), 'message' => $this->getMessage(true), 'category' => 'message'));
 			event::add('message::refreshMessageNumber');
 		}
 		return true;

--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -329,14 +329,14 @@ class network {
 			$plugin = plugin::byId('openvpn');
 		}
 		if (!is_object($plugin)) {
-			throw new Exception(__('Le plugin OpenVPN doit être installé', __FILE__));
+			throw new Exception(new Trad('Le plugin OpenVPN doit être installé', __FILE__));
 		}
 		if (!$plugin->isActive()) {
 			$plugin->setIsEnable(1);
 			$plugin->dependancy_install();
 		}
 		if (!$plugin->isActive()) {
-			throw new Exception(__('Le plugin OpenVPN doit être actif', __FILE__));
+			throw new Exception(new Trad('Le plugin OpenVPN doit être actif', __FILE__));
 		}
 		$openvpn = eqLogic::byLogicalId('dnsjeedom', 'openvpn');
 		$direct = true;
@@ -376,7 +376,7 @@ class network {
 		}
 		copy(__DIR__ . '/../../resources/ca_dns.crt', $path_ca);
 		if (!file_exists($path_ca)) {
-			throw new Exception(__('Impossible de créer le fichier  :', __FILE__) . ' ' . $path_ca);
+			throw new Exception(new Trad('Impossible de créer le fichier  :', __FILE__) . ' ' . $path_ca);
 		}
 		return $openvpn;
 	}
@@ -392,7 +392,7 @@ class network {
 		$vpn = self::dns_create();
 		$cmd = $vpn->getCmd('action', 'start');
 		if (!is_object($cmd)) {
-			throw new Exception(__('La commande de démarrage du DNS est introuvable', __FILE__));
+			throw new Exception(new Trad('La commande de démarrage du DNS est introuvable', __FILE__));
 		}
 		$cmd->execCmd();
 	}
@@ -411,7 +411,7 @@ class network {
 		}
 		$cmd = $vpn->getCmd('info', 'state');
 		if (!is_object($cmd)) {
-			throw new Exception(__('La commande de statut du DNS est introuvable', __FILE__));
+			throw new Exception(new Trad('La commande de statut du DNS est introuvable', __FILE__));
 		}
 		return $cmd->execCmd();
 	}
@@ -423,7 +423,7 @@ class network {
 		$vpn = self::dns_create();
 		$cmd = $vpn->getCmd('action', 'stop');
 		if (!is_object($cmd)) {
-			throw new Exception(__('La commande d\'arrêt du DNS est introuvable', __FILE__));
+			throw new Exception(new Trad('La commande d\'arrêt du DNS est introuvable', __FILE__));
 		}
 		$cmd->execCmd();
 	}
@@ -449,7 +449,7 @@ class network {
 			if (!network::test('external')) {
 				sleep(rand(20, 60));
 				if (!network::test('external')) {
-					log::add('network', 'warning', __('Accès externe non ok, redémarrage du dns Jeedom', __FILE__));
+					log::add('network', 'warning', new Trad('Accès externe non ok, redémarrage du dns Jeedom', __FILE__));
 					self::dns_stop();
 					self::dns_start();
 				}
@@ -467,7 +467,7 @@ class network {
 		}
 		$gw = shell_exec("ip route show default | awk '/default/ {print $3}'");
 		if ($gw == '') {
-			log::add('network', 'error', __('Souci réseau détecté, redémarrage du réseau. Aucune gateway de trouvée', __FILE__));
+			log::add('network', 'error', new Trad('Souci réseau détecté, redémarrage du réseau. Aucune gateway de trouvée', __FILE__));
 			exec(system::getCmdSudo() . 'service networking restart');
 			return;
 		}
@@ -479,7 +479,7 @@ class network {
 		if ($return_val == 0) {
 			return;
 		}
-		log::add('network', 'error', __('Souci réseau détecté, redémarrage du réseau. La gateway ne répond pas au ping :', __FILE__) . ' ' . $gw);
+		log::add('network', 'error', new Trad('Souci réseau détecté, redémarrage du réseau. La gateway ne répond pas au ping :', __FILE__) . ' ' . $gw);
 		exec(system::getCmdSudo() . 'service networking restart');
 	}
 }

--- a/core/class/note.class.php
+++ b/core/class/note.class.php
@@ -49,7 +49,7 @@ class note {
 
 	public function preSave() {
 		if (trim($this->getName()) == '') {
-			throw new Exception(__('Le nom de la note ne peut être vide', __FILE__));
+			throw new Exception(new Trad('Le nom de la note ne peut être vide', __FILE__));
 		}
 	}
 

--- a/core/class/plan.class.php
+++ b/core/class/plan.class.php
@@ -218,7 +218,7 @@ class plan {
 				$options['source'] = 'Design ' . $this->getPlanHeader()->getName() . ' ' . $action['cmd'];
 				scenarioExpression::createAndExec('action', $action['cmd'], $options);
 			} catch (Exception $e) {
-				log::add('design', 'error', __('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . __('Détails :', __FILE__) . ' ' . log::exception($e));
+				log::add('design', 'error', new Trad('Erreur lors de l\'exécution de', __FILE__) . ' ' . $action['cmd'] . '. ' . new Trad('Détails :', __FILE__) . ' ' . log::exception($e));
 			}
 		}
 	}
@@ -332,7 +332,7 @@ class plan {
 				}
 			}
 			if ($summary == '') {
-				$html .= __('Non configuré', __FILE__);
+				$html .= new Trad('Non configuré', __FILE__);
 			} else {
 				$html .= $summary;
 			}

--- a/core/class/plan3dHeader.class.php
+++ b/core/class/plan3dHeader.class.php
@@ -76,7 +76,7 @@ class plan3dHeader {
 
 	public function preSave() {
 		if (trim($this->getName()) == '') {
-			throw new Exception(__('Le nom du l\'objet ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('Le nom du l\'objet ne peut pas être vide', __FILE__));
 		}
 	}
 
@@ -111,7 +111,7 @@ class plan3dHeader {
 		$icon = findCodeIcon($this->getConfiguration('icon', '<i class="fas fa-paint-brush"></i>'));
 		$_data['node']['plan3d' . $this->getId()] = array(
 			'id' => 'plan3d' . $this->getId(),
-			'type' => __('Design 3d', __FILE__),
+			'type' => new Trad('Design 3d', __FILE__),
 			'name' => substr($this->getName(), 0, 20),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],
@@ -119,7 +119,7 @@ class plan3dHeader {
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
 			'texty' => -14,
 			'textx' => 0,
-			'title' => __('Design 3d :', __FILE__) . ' ' . $this->getName(),
+			'title' => new Trad('Design 3d :', __FILE__) . ' ' . $this->getName(),
 			'url' => 'index.php?v=d&p=plan3d&plan3d_id=' . $this->getId(),
 		);
 	}

--- a/core/class/planHeader.class.php
+++ b/core/class/planHeader.class.php
@@ -105,7 +105,7 @@ class planHeader {
 
 	public function preSave() {
 		if (trim($this->getName()) == '') {
-			throw new Exception(__('Le nom du plan ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('Le nom du plan ne peut pas être vide', __FILE__));
 		}
 		if ($this->getConfiguration('desktopSizeX') == '') {
 			$this->setConfiguration('desktopSizeX', 500);
@@ -166,7 +166,7 @@ class planHeader {
 		$icon = findCodeIcon($this->getConfiguration('icon', '<i class="fas fa-paint-brush"></i>'));
 		$_data['node']['plan' . $this->getId()] = array(
 			'id' => 'plan' . $this->getId(),
-			'type' => __('Design', __FILE__),
+			'type' => new Trad('Design', __FILE__),
 			'name' => substr($this->getName(), 0, 20),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],
@@ -174,7 +174,7 @@ class planHeader {
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
 			'texty' => -14,
 			'textx' => 0,
-			'title' => __('Design :', __FILE__) . ' ' . $this->getName(),
+			'title' => new Trad('Design :', __FILE__) . ' ' . $this->getName(),
 			'url' => 'index.php?v=d&p=plan&plan_id=' . $this->getId(),
 		);
 	}

--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -259,7 +259,7 @@ class plugin {
 				foreach ($listPlugin as $plugin) {
 					$category = $plugin->getCategory();
 					if ($category == '') {
-						$category = __('Autre', __FILE__);
+						$category = new Trad('Autre', __FILE__);
 					}
 					if (!isset($return[$category])) {
 						$return[$category] = array();
@@ -332,9 +332,9 @@ class plugin {
 					continue;
 				}
 				if (!$ok) {
-					$message = __('Attention le plugin', __FILE__) . ' ' . $plugin->getName();
-					$message .= ' ' . __('n\'a pas recu de message depuis', __FILE__) . ' ' . $heartbeat . ' ' . __('min', __FILE__);
-					$action = '<a href="/' . $plugin->getLinkToConfiguration() . '">' . __('Configuration', __FILE__) . '</a>';
+					$message = new Trad('Attention le plugin', __FILE__) . ' ' . $plugin->getName();
+					$message .= ' ' . new Trad('n\'a pas recu de message depuis', __FILE__) . ' ' . $heartbeat . ' ' . new Trad('min', __FILE__);
+					$action = '<a href="/' . $plugin->getLinkToConfiguration() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 					$logicalId = 'heartbeat' . $plugin->getId();
 					message::add($plugin->getId(), $message, $action, $logicalId);
 					if ($plugin->getHasOwnDeamon() && config::byKey('heartbeat::restartDeamon::' . $plugin->getId(), 'core', 0) == 1) {
@@ -353,8 +353,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cron::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cron n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cron n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cron::inprogress', $cache->getValue(0) + 1);
@@ -368,9 +368,9 @@ class plugin {
 				try {
 					$plugin_id::cron();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -384,8 +384,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cron5::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cron5 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron5::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron5::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cron5 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron5::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron5::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cron5::inprogress', $cache->getValue(0) + 1);
@@ -399,9 +399,9 @@ class plugin {
 				try {
 					$plugin_id::cron5();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron5 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron5 du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron5 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron5 du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -415,8 +415,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cron10::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cron10 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron10::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron10::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cron10 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron10::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron10::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cron10::inprogress', $cache->getValue(0) + 1);
@@ -430,9 +430,9 @@ class plugin {
 				try {
 					$plugin_id::cron10();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron10 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron10 du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron10 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron10 du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -446,8 +446,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cron15::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cron15 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron15::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron15::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cron15 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron15::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron15::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cron15::inprogress', $cache->getValue(0) + 1);
@@ -461,9 +461,9 @@ class plugin {
 				try {
 					$plugin_id::cron15();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron15 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron15 du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron15 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron15 du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -477,8 +477,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cron30::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cron30 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron30::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron30::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cron30 n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cron30::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cron30::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cron30::inprogress', $cache->getValue(0) + 1);
@@ -492,9 +492,9 @@ class plugin {
 				try {
 					$plugin_id::cron30();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron30 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron30 du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cron30 du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cron30 du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -508,8 +508,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cronDaily::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cronDaily n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cronDaily::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cronDaily::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cronDaily n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cronDaily::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cronDaily::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cronDaily::inprogress', $cache->getValue(0) + 1);
@@ -523,9 +523,9 @@ class plugin {
 				try {
 					$plugin_id::cronDaily();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cronDaily du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cronDaily du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cronDaily du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cronDaily du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -539,8 +539,8 @@ class plugin {
 			$cache = cache::byKey('plugin::cronHourly::inprogress');
 		}
 		if ($cache->getValue(0) > 3) {
-			$message = __('La tâche plugin::cronHourly n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cronHourly::last')->getValue() . ' ' . __('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
-			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cronHourly::last')->getValue() . '">' . __('Configuration', __FILE__) . '</a>';
+			$message = new Trad('La tâche plugin::cronHourly n\'arrive pas à finir à cause du plugin :', __FILE__) . ' ' . cache::byKey('plugin::cronHourly::last')->getValue() . ' ' . new Trad('nous vous conseillons de désactiver le plugin et de contacter l\'auteur', __FILE__);
+			$action = '<a href="/index.php?v=d&p=plugin&id=' . cache::byKey('plugin::cronHourly::last')->getValue() . '">' . new Trad('Configuration', __FILE__) . '</a>';
 			message::add('core', $message, $action);
 		}
 		cache::set('plugin::cronHourly::inprogress', $cache->getValue(0) + 1);
@@ -554,9 +554,9 @@ class plugin {
 				try {
 					$plugin_id::cronHourly();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cronHourly du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cronHourly du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction cronHourly du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction cronHourly du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -571,9 +571,9 @@ class plugin {
 				try {
 					$plugin_id::start();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction start du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction start du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction start du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction start du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -587,9 +587,9 @@ class plugin {
 				try {
 					$plugin_id::stop();
 				} catch (Exception $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction stop du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction stop du plugin :', __FILE__) . ' ' . log::exception($e));
 				} catch (Error $e) {
-					log::add($plugin_id, 'error', __('Erreur sur la fonction stop du plugin :', __FILE__) . ' ' . log::exception($e));
+					log::add($plugin_id, 'error', new Trad('Erreur sur la fonction stop du plugin :', __FILE__) . ' ' . log::exception($e));
 				}
 			}
 		}
@@ -610,7 +610,7 @@ class plugin {
 				if (isset($dependancy_info['progress_file']) && file_exists($dependancy_info['progress_file'])) {
 					shell_exec('rm ' . $dependancy_info['progress_file']);
 				}
-				log::add($plugin->getId(), 'error', __('Attention : l\'installation des dépendances a dépassé le temps maximum autorisé :', __FILE__) . ' ' . $plugin->getMaxDependancyInstallTime() . 'min');
+				log::add($plugin->getId(), 'error', new Trad('Attention : l\'installation des dépendances a dépassé le temps maximum autorisé :', __FILE__) . ' ' . $plugin->getMaxDependancyInstallTime() . 'min');
 			}
 			try {
 				$plugin->deamon_start(false, true);
@@ -632,7 +632,7 @@ class plugin {
 
 	public function report($_format = 'pdf', $_parameters = array()) {
 		if ($this->getDisplay() == '') {
-			throw new Exception(__('Vous ne pouvez pas faire de rapport sur un plugin sans panneau', __FILE__));
+			throw new Exception(new Trad('Vous ne pouvez pas faire de rapport sur un plugin sans panneau', __FILE__));
 		}
 		$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=' . $this->getDisplay();
 		$url .= '&m=' . $this->getId();
@@ -663,7 +663,7 @@ class plugin {
 		if (strpos($_function, 'pre_') !== false) {
 			log::add('plugin', 'debug', 'Recherche de ' . __DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/pre_install.php');
 			if (file_exists(__DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/pre_install.php')) {
-				log::add('plugin', 'debug', __('Fichier d\'installation trouvé pour  :', __FILE__) . ' ' . $this->getId());
+				log::add('plugin', 'debug', new Trad('Fichier d\'installation trouvé pour  :', __FILE__) . ' ' . $this->getId());
 				require_once __DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/pre_install.php';
 				ob_start();
 				$function = $this->getId() . '_' . $_function;
@@ -675,7 +675,7 @@ class plugin {
 		} else {
 			log::add('plugin', 'debug', 'Recherche de ' . __DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/install.php');
 			if (file_exists(__DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/install.php')) {
-				log::add('plugin', 'debug', __('Fichier d\'installation trouvé pour  :', __FILE__) . ' ' . $this->getId());
+				log::add('plugin', 'debug', new Trad('Fichier d\'installation trouvé pour  :', __FILE__) . ' ' . $this->getId());
 				require_once __DIR__ . '/../../plugins/' . $this->getId() . '/plugin_info/install.php';
 				ob_start();
 				$function = $this->getId() . '_' . $_function;
@@ -723,7 +723,7 @@ class plugin {
 			} else {
 				$return['duration'] = -1;
 			}
-			$return['last_launch'] = config::byKey('lastDependancyInstallTime', $this->getId(), __('Inconnue', __FILE__));
+			$return['last_launch'] = config::byKey('lastDependancyInstallTime', $this->getId(), new Trad('Inconnue', __FILE__));
 			$return['auto'] = config::byKey('dependancyAutoMode', $this->getId(), 1);
 			if ($return['state'] != 'in_progress' && method_exists($plugin_id, 'additionnalDependancyCheck')) {
 				$additionnal = $plugin_id::additionnalDependancyCheck();
@@ -761,7 +761,7 @@ class plugin {
 		} else {
 			$return['duration'] = -1;
 		}
-		$return['last_launch'] = config::byKey('lastDependancyInstallTime', $this->getId(), __('Inconnue', __FILE__));
+		$return['last_launch'] = config::byKey('lastDependancyInstallTime', $this->getId(), new Trad('Inconnue', __FILE__));
 		$return['auto'] = config::byKey('dependancyAutoMode', $this->getId(), 1);
 		if ($return['state'] == 'ok') {
 			cache::set('dependancy' . $this->getID(), $return);
@@ -778,11 +778,11 @@ class plugin {
 		if (!$_force && config::byKey('dontProtectTooFastLaunchDependancy') == 0 && abs(strtotime('now') - strtotime(config::byKey('lastDependancyInstallTime', $plugin_id))) <= 60) {
 			$cache = cache::byKey('dependancy' . $this->getID());
 			$cache->remove();
-			throw new Exception(__('Vous devez attendre au moins 60 secondes entre deux lancements d\'installation de dépendances', __FILE__));
+			throw new Exception(new Trad('Vous devez attendre au moins 60 secondes entre deux lancements d\'installation de dépendances', __FILE__));
 		}
 		$dependancy_info = $this->dependancy_info(true);
 		if ($dependancy_info['state'] == 'in_progress') {
-			throw new Exception(__('Les dépendances sont déjà en cours d\'installation', __FILE__));
+			throw new Exception(new Trad('Les dépendances sont déjà en cours d\'installation', __FILE__));
 		}
 		if (file_exists(__DIR__ . '/../../plugins/' . $plugin_id . '/plugin_info/packages.json')) {
 			$this->deamon_stop();
@@ -801,7 +801,7 @@ class plugin {
 			}
 			$dependancy_info = $plugin->dependancy_info();
 			if ($dependancy_info['state'] == 'in_progress') {
-				throw new Exception(__('Les dépendances d\'un autre plugin sont déjà en cours, veuillez attendre qu\'elles soient finies :', __FILE__) . ' ' . $plugin->getId());
+				throw new Exception(new Trad('Les dépendances d\'un autre plugin sont déjà en cours, veuillez attendre qu\'elles soient finies :', __FILE__) . ' ' . $plugin->getId());
 			}
 		}
 		$cmd = $plugin_id::dependancy_install();
@@ -811,8 +811,8 @@ class plugin {
 			if (file_exists($script_array[0])) {
 				if (jeedom::isCapable('sudo')) {
 					$this->deamon_stop();
-					$message = __('Attention : installation des dépendances lancée', __FILE__);
-					$action = '<a href="/index.php?v=d&p=plugin&id=' . $plugin_id . '">' . __('Configuration', __FILE__) . '</a>';
+					$message = new Trad('Attention : installation des dépendances lancée', __FILE__);
+					$action = '<a href="/index.php?v=d&p=plugin&id=' . $plugin_id . '">' . new Trad('Configuration', __FILE__) . '</a>';
 					message::add($plugin_id, $message, $action);
 					config::save('lastDependancyInstallTime', date('Y-m-d H:i:s'), $plugin_id);
 					if (exec('which at | wc -l') == 0) {
@@ -825,10 +825,10 @@ class plugin {
 					}
 					sleep(1);
 				} else {
-					log::add($plugin_id, 'error', __('Veuillez exécuter le script :', __FILE__) . ' /bin/bash ' . $script);
+					log::add($plugin_id, 'error', new Trad('Veuillez exécuter le script :', __FILE__) . ' /bin/bash ' . $script);
 				}
 			} else {
-				log::add($plugin_id, 'error', __('Aucun script ne correspond à votre type de Linux :', __FILE__) . ' ' . $cmd['script'] . ' ' . __('avec #stype# :', __FILE__) . ' ' . system::get('type'));
+				log::add($plugin_id, 'error', new Trad('Aucun script ne correspond à votre type de Linux :', __FILE__) . ' ' . $cmd['script'] . ' ' . new Trad('avec #stype# :', __FILE__) . ' ' . system::get('type'));
 			}
 		}
 		$cache = cache::byKey('dependancy' . $this->getID());
@@ -867,9 +867,9 @@ class plugin {
 			if ($dependancy_info['state'] != 'ok') {
 				$return['launchable'] = 'nok';
 				if ($dependancy_info['state'] == 'in_progress') {
-					$return['launchable_message'] = __('Dépendances en cours d\'installation', __FILE__);
+					$return['launchable_message'] = new Trad('Dépendances en cours d\'installation', __FILE__);
 				} else {
-					$return['launchable_message'] = __('Dépendances non installées', __FILE__);
+					$return['launchable_message'] = new Trad('Dépendances non installées', __FILE__);
 				}
 			}
 		}
@@ -881,17 +881,17 @@ class plugin {
 		}
 		$return['auto'] = config::byKey('deamonAutoMode', $this->getId(), 1);
 		if ($return['auto'] == 0) {
-			$return['launchable_message'] = __('Gestion automatique désactivée', __FILE__);
+			$return['launchable_message'] = new Trad('Gestion automatique désactivée', __FILE__);
 		}
 		if (config::byKey('enableCron', 'core', 1, true) == 0) {
 			$return['launchable'] = 'nok';
-			$return['launchable_message'] = __('Les crons et démons sont désactivés', __FILE__);
+			$return['launchable_message'] = new Trad('Les crons et démons sont désactivés', __FILE__);
 		}
 		if (!jeedom::isStarted()) {
 			$return['launchable'] = 'nok';
-			$return['launchable_message'] = __('Jeedom n\'est pas encore démarré', __FILE__);
+			$return['launchable_message'] = new Trad('Jeedom n\'est pas encore démarré', __FILE__);
 		}
-		$return['last_launch'] = config::byKey('lastDeamonLaunchTime', $this->getId(), __('Inconnue', __FILE__));
+		$return['last_launch'] = config::byKey('lastDeamonLaunchTime', $this->getId(), new Trad('Inconnue', __FILE__));
 		return $return;
 	}
 
@@ -918,11 +918,11 @@ class plugin {
 							return;
 						}
 						if (config::byKey('dontProtectTooFastLaunchDeamony') == 0) {
-							throw new Exception(__('Vous devez attendre au moins 45 secondes entre deux lancements du démon. Dernier lancement :', __FILE__) . ' ' . date("Y-m-d H:i:s", $info['datetime']));
+							throw new Exception(new Trad('Vous devez attendre au moins 45 secondes entre deux lancements du démon. Dernier lancement :', __FILE__) . ' ' . date("Y-m-d H:i:s", $info['datetime']));
 						}
 					}
 					if (config::byKey('deamonRestartNumber', $plugin_id, 0) > 3) {
-						log::add($plugin_id, 'error', __('Attention je pense qu\'il y a un soucis avec le démon que j\'ai relancé plus de 3 fois consécutivement', __FILE__));
+						log::add($plugin_id, 'error', new Trad('Attention je pense qu\'il y a un soucis avec le démon que j\'ai relancé plus de 3 fois consécutivement', __FILE__));
 					}
 					if (!$_forceRestart) {
 						config::save('deamonRestartNumber', config::byKey('deamonRestartNumber', $plugin_id, 0) + 1, $plugin_id);
@@ -938,9 +938,9 @@ class plugin {
 				}
 			}
 		} catch (Exception $e) {
-			log::add($plugin_id, 'error', __('Erreur sur la fonction deamon_start du plugin :', __FILE__) . ' ' . log::exception($e));
+			log::add($plugin_id, 'error', new Trad('Erreur sur la fonction deamon_start du plugin :', __FILE__) . ' ' . log::exception($e));
 		} catch (Error $e) {
-			log::add($plugin_id, 'error', __('Erreur sur la fonction deamon_start du plugin :', __FILE__) . ' ' . log::exception($e));
+			log::add($plugin_id, 'error', new Trad('Erreur sur la fonction deamon_start du plugin :', __FILE__) . ' ' . log::exception($e));
 		}
 	}
 
@@ -954,21 +954,21 @@ class plugin {
 				}
 			}
 		} catch (Exception $e) {
-			log::add($plugin_id, 'error', __('Erreur sur la fonction deamon_stop du plugin :', __FILE__) . ' ' . log::exception($e));
+			log::add($plugin_id, 'error', new Trad('Erreur sur la fonction deamon_stop du plugin :', __FILE__) . ' ' . log::exception($e));
 		} catch (Error $e) {
-			log::add($plugin_id, 'error', __('Erreur sur la fonction deamon_stop du plugin :', __FILE__) . ' ' . log::exception($e));
+			log::add($plugin_id, 'error', new Trad('Erreur sur la fonction deamon_stop du plugin :', __FILE__) . ' ' . log::exception($e));
 		}
 	}
 
 	public function setIsEnable($_state, $_force = false, $_foreground = false) {
 		if (version_compare(jeedom::version(), $this->getRequire()) == -1 && $_state == 1) {
-			throw new Exception(__('Votre version de Jeedom n\'est pas assez récente pour activer ce plugin', __FILE__));
+			throw new Exception(new Trad('Votre version de Jeedom n\'est pas assez récente pour activer ce plugin', __FILE__));
 		}
 		$osVersion = $this->getRequireOsVersion();
 		$distrib = system::getDistrib();
 		if(isset($osVersion)){
 			if ($distrib == 'debian' && version_compare(system::getOsVersion(), $osVersion) == -1 && $_state == 1) {
-				throw new Exception(__('Votre version Debian n\'est pas assez récente pour activer cette version du plugin, '.$osVersion.' minimum demandé', __FILE__));
+				throw new Exception(new Trad('Votre version Debian n\'est pas assez récente pour activer cette version du plugin, '.$osVersion.' minimum demandé', __FILE__));
 			}
 		}
 		$alreadyActive = config::byKey('active', $this->getId(), 0);
@@ -1083,7 +1083,7 @@ class plugin {
 		if (jeedom::checkOngoingThread($cmd) > 0) {
 			return true;
 		}
-		log::add($this->getId(), 'debug', __('Lancement de :', __FILE__) . ' ' . $cmd);
+		log::add($this->getId(), 'debug', new Trad('Lancement de :', __FILE__) . ' ' . $cmd);
 		if ($_callInstallFunction) {
 			return system::php($cmd . ' >> /dev/null 2>&1');
 		} else {
@@ -1138,7 +1138,7 @@ class plugin {
 		// check if connexion used jeedom DNS
 		$url =  network::getNetworkAccess('external');
 		$hasDns  = ((strpos($url, 'jeedom.com') !== false || strpos($url, 'eu.jeedom.link')) !== false);
-		$infoCore .= 'DNS ' . config::byKey('product_name') . ' : ' . ($hasDns ? __('oui', __FILE__) : __('non', __FILE__));
+		$infoCore .= 'DNS ' . config::byKey('product_name') . ' : ' . ($hasDns ? new Trad('oui', __FILE__) : new Trad('non', __FILE__));
 		$infoCore .= $_separator;
 
 		return $infoCore;

--- a/core/class/queue.class.php
+++ b/core/class/queue.class.php
@@ -113,24 +113,24 @@ class queue {
                 continue;
             }
             try {
-                log::add('queue','debug',__('Lancement de '.$queue->getHumanName(),__FILE__));
+                log::add('queue','debug',new Trad('Lancement de '.$queue->getHumanName(), __FILE__));
                 $queue->run();
             } catch (\Throwable $th) {
-                log::add('queue','debug',__('Erreur sur le lancement de '.$queue->getHumanName().' => '.$th->getMessage(),__FILE__));
+                log::add('queue','debug',new Trad('Erreur sur le lancement de '.$queue->getHumanName().' => '.$th->getMessage(), __FILE__));
             }
         }
         $queueIds = self::allQueueId();
         foreach ($queueIds as $queueId) {
-            log::add('queue','debug',__('Recherche des actions à faire pour '.$queueId['queueId'],__FILE__));
+            log::add('queue','debug',new Trad('Recherche des actions à faire pour '.$queueId['queueId'], __FILE__));
             $queue = self::firstByQueueId($queueId['queueId']);
             if(!$queue->canRun()){
                 continue;
             }
             try {
-                log::add('queue','debug',__('Lancement de '.$queue->getHumanName(),__FILE__));
+                log::add('queue','debug',new Trad('Lancement de '.$queue->getHumanName(), __FILE__));
                 $queue->run();
             } catch (\Throwable $th) {
-                log::add('queue','debug',__('Erreur sur le lancement de '.$queue->getHumanName().' => '.$th->getMessage(),__FILE__));
+                log::add('queue','debug',new Trad('Erreur sur le lancement de '.$queue->getHumanName().' => '.$th->getMessage(), __FILE__));
             }
         }
     }
@@ -165,7 +165,7 @@ class queue {
 				if (!$this->running()) {
 					system::php($cmd . ' >> ' . log::getPathToLog('queue_execution') . ' 2>&1 &');
 				} else {
-					throw new Exception(__('Impossible d\'exécuter la tâche en queue car elle est déjà en cours d\'exécution (', __FILE__) . ' : ' . $cmd);
+					throw new Exception(new Trad('Impossible d\'exécuter la tâche en queue car elle est déjà en cours d\'exécution (', __FILE__) . ' : ' . $cmd);
 				}
 			}
 		}
@@ -198,7 +198,7 @@ class queue {
 			$this->setState('stop');
 			$this->setPID();
 		} else {
-			log::add('queue', 'info', __('Arrêt de', __FILE__) . ' ' . $this->getHumanName() . ', PID : ' . $this->getPID());
+			log::add('queue', 'info', new Trad('Arrêt de', __FILE__) . ' ' . $this->getHumanName() . ', PID : ' . $this->getPID());
 			if ($this->getPID() > 0) {
 				system::kill($this->getPID());
 			}
@@ -212,7 +212,7 @@ class queue {
 				if ($this->running()) {
 					$this->setState('error');
 					$this->setPID();
-					throw new Exception($this->getHumanName() . __(' : Impossible d\'arrêter la tâche en queue', __FILE__));
+					throw new Exception($this->getHumanName() . new Trad(' : Impossible d\'arrêter la tâche en queue', __FILE__));
 				}
 			} else {
 				$this->setState('stop');
@@ -236,16 +236,16 @@ class queue {
 
     public function preSave(){
         if($this->getClass() == '' && $this->getFunction() == ''){
-            throw new Exception(__('La classe est la fonction ne peuvent etre vides',__FILE__));
+            throw new Exception(new Trad('La classe est la fonction ne peuvent etre vides', __FILE__));
         }
         if($this->getClass() != '' && !class_exists($this->getClass())){
-            throw new Exception(__('La classe n\'existe pas',__FILE__));
+            throw new Exception(new Trad('La classe n\'existe pas', __FILE__));
         }
         if($this->getClass() == '' && $this->getFunction() != '' && !function_exists($this->getFunction())){
-            throw new Exception(__('La fonction n\'existe pas',__FILE__));
+            throw new Exception(new Trad('La fonction n\'existe pas', __FILE__));
         }
         if($this->getClass() != '' && $this->getFunction() != '' && !method_exists($this->getClass(),$this->getFunction())){
-            throw new Exception(__('La methode n\'existe pas',__FILE__));
+            throw new Exception(new Trad('La methode n\'existe pas', __FILE__));
         }
         if($this->getCreateTime() == ''){
             $this->setCreateTime(date('Y-m-d H:i:s'));

--- a/core/class/recovery.class.php
+++ b/core/class/recovery.class.php
@@ -38,9 +38,9 @@ class recovery {
 	public static function install(bool $_force = false): bool {
 		switch (system::getArch()) {
 			case 'arm64':
-				self::writeLog(__('Vérification du script de démarrage', __FILE__));
+				self::writeLog(new Trad('Vérification du script de démarrage', __FILE__));
 				if (!$_force && self::isInstalled()) {
-					self::writeLog(__('Le script de démarrage est à jour', __FILE__), 'debug');
+					self::writeLog(new Trad('Le script de démarrage est à jour', __FILE__), 'debug');
 					return true;
 				}
 
@@ -49,14 +49,14 @@ class recovery {
 				$cmd .= ' >> ' . log::getPathToLog(__CLASS__) . ' 2>&1';
 				exec($cmd, $output, $returnCode);
 				if ($returnCode == 0) {
-					self::writeLog(__('Le script de démarrage a été mis à jour', __FILE__), 'debug');
+					self::writeLog(new Trad('Le script de démarrage a été mis à jour', __FILE__), 'debug');
 					if (!self::isInstalled()) {
 						shell_exec('echo ' . ucfirst(jeedom::getHardwareName()) . ' | sudo tee /etc/jeedom_board');
 					}
 					return true;
 				}
 
-				self::writeLog(__('Impossible de mettre à jour le script de démarrage', __FILE__), 'error');
+				self::writeLog(new Trad('Impossible de mettre à jour le script de démarrage', __FILE__), 'error');
 				return false;
 			default:
 				return false;
@@ -66,8 +66,8 @@ class recovery {
 	public static function start(string $_hardware, string $_mode = 'auto'): bool {
 		cache::delete(self::CANCEL);
 		cache::set(self::PROGRESS, false, 60);
-		self::writeLog('-----------------------------------------------------------------------------------------', __('Restauration', __FILE__) . ' ' . $_hardware);
-		self::setProgress(['step' => __('Initialisation', __FILE__) . ' (' . strtoupper($_mode) . ')', 'details' => __('Initialisation de la procédure de restauration système', __FILE__), 'progress' => 0], 2);
+		self::writeLog('-----------------------------------------------------------------------------------------', new Trad('Restauration', __FILE__) . ' ' . $_hardware);
+		self::setProgress(['step' => new Trad('Initialisation', __FILE__) . ' (' . strtoupper($_mode) . ')', 'details' => new Trad('Initialisation de la procédure de restauration système', __FILE__), 'progress' => 0], 2);
 
 		try {
 			switch (system::getArch()) {
@@ -85,31 +85,31 @@ class recovery {
 					}
 					self::downloadAndValidateImage($imgInfos['url'], $downloadPath . '/' . $imgInfos['name'], $imgInfos['SHA256']);
 
-					self::setProgress(['step' => __('Finalisation', __FILE__) . ' (' . strtoupper($_mode) . ')', 'details' => __('Finalisation de la procédure de restauration système', __FILE__), 'progress' => 98], 2);
+					self::setProgress(['step' => new Trad('Finalisation', __FILE__) . ' (' . strtoupper($_mode) . ')', 'details' => new Trad('Finalisation de la procédure de restauration système', __FILE__), 'progress' => 98], 2);
 					if ($_mode == 'usb') {
 						if (!file_exists($downloadPath . '/' . self::DEFAULT_IMGNAME)) {
-							self::setProgress(['details' => __('Ecriture du fichier de configuration USB', __FILE__), 'progress' => 99], 1);
+							self::setProgress(['details' => new Trad('Ecriture du fichier de configuration USB', __FILE__), 'progress' => 99], 1);
 							if (!file_put_contents($downloadPath . '/JeedomSystemUpdate.ini', 'update_filename="' . $imgInfos['name'] . '"')) {
-								throw new Exception(__('Une erreur est survenue lors de la finalisation de la procédure de restauration système', __FILE__));
+								throw new Exception(new Trad('Une erreur est survenue lors de la finalisation de la procédure de restauration système', __FILE__));
 							}
 						}
 						shell_exec('sudo umount ' . $downloadPath);
-						$message = __('Le nouveau système est prêt à être installé depuis la clé USB de restauration', __FILE__);
-						$message .= "\n\n" . __('Veuillez redémarrer avec la clé USB branchée dans le port en haut à droite pour effectuer la restauration', __FILE__);
+						$message = new Trad('Le nouveau système est prêt à être installé depuis la clé USB de restauration', __FILE__);
+						$message .= "\n\n" . new Trad('Veuillez redémarrer avec la clé USB branchée dans le port en haut à droite pour effectuer la restauration', __FILE__);
 					} else {
 						if (!file_exists($downloadPath . '/' . self::DEFAULT_IMGNAME)) {
-							self::setProgress(['details' => __('Renommage du fichier de restauration système', __FILE__), 'progress' => 99], 1);
+							self::setProgress(['details' => new Trad('Renommage du fichier de restauration système', __FILE__), 'progress' => 99], 1);
 							if (!rename($downloadPath . '/' . $imgInfos['name'], $downloadPath . '/' . self::DEFAULT_IMGNAME)) {
-								throw new Exception(__('Une erreur est survenue lors de la finalisation de la procédure de restauration système', __FILE__));
+								throw new Exception(new Trad('Une erreur est survenue lors de la finalisation de la procédure de restauration système', __FILE__));
 							}
 						}
-						$message = __('Le nouveau système est prêt à être déployé automatiquement au prochain démarrage', __FILE__);
-						$message .= "\n\n" . __('Veuillez redémarrer pour effectuer la restauration', __FILE__);
+						$message = new Trad('Le nouveau système est prêt à être déployé automatiquement au prochain démarrage', __FILE__);
+						$message .= "\n\n" . new Trad('Veuillez redémarrer pour effectuer la restauration', __FILE__);
 					}
-					self::setProgress(['step' => __("Félicitations", __FILE__), 'details' => $message, 'progress' => 100], 2);
+					self::setProgress(['step' => new Trad("Félicitations", __FILE__), 'details' => $message, 'progress' => 100], 2);
 					return true;
 				default:
-					throw new Exception(__('Cette fonctionnalité est uniquement disponible sur les systèmes à base ARM64', __FILE__));
+					throw new Exception(new Trad('Cette fonctionnalité est uniquement disponible sur les systèmes à base ARM64', __FILE__));
 			}
 		} catch (Exception $e) {
 			self::setProgress(['details' => $e->getMessage(), 'progress' => -1], 2);
@@ -176,7 +176,7 @@ class recovery {
 	}
 
 	private static function downloadAndValidateImage(string $_url, string $_filepath, string $_sha256): void {
-		self::setProgress(['step' => __("Téléchargement de l'image système", __FILE__), 'details' => __('Début du téléchargement', __FILE__), 'progress' => 5], 2);
+		self::setProgress(['step' => new Trad("Téléchargement de l'image système", __FILE__), 'details' => new Trad('Début du téléchargement', __FILE__), 'progress' => 5], 2);
 		if (file_exists($imgPath = $_filepath) || file_exists($imgPath = dirname($_filepath) . '/' . self::DEFAULT_IMGNAME)) {
 			try {
 				self::validateImage($imgPath, $_sha256, false);
@@ -185,7 +185,7 @@ class recovery {
 				if (cache::exist(self::CANCEL)) {
 					throw new Exception($e->getMessage());
 				} else {
-					self::setProgress(['details' => __('Image système invalide, reprise du téléchargement', __FILE__), 'progress' => 5], 1);
+					self::setProgress(['details' => new Trad('Image système invalide, reprise du téléchargement', __FILE__), 'progress' => 5], 1);
 				}
 			}
 		}
@@ -208,9 +208,9 @@ class recovery {
 		curl_exec($ch);
 
 		if (curl_errno($ch)) {
-			$error = __("Erreur lors du téléchargement", __FILE__) . ' : ' . curl_error($ch);
+			$error = new Trad("Erreur lors du téléchargement", __FILE__) . ' : ' . curl_error($ch);
 			if (cache::exist(self::CANCEL)) {
-				$error = __("Téléchargement annulé à la demande de l'utilisateur", __FILE__);
+				$error = new Trad("Téléchargement annulé à la demande de l'utilisateur", __FILE__);
 			}
 		}
 
@@ -242,9 +242,9 @@ class recovery {
 
 	private static function validateImage(string $_filepath, string $_sha256, bool $_downloaded = true): void {
 		if ($_downloaded) {
-			$message = __("Vérification de l'intégrité de l'image système téléchargée", __FILE__);
+			$message = new Trad("Vérification de l'intégrité de l'image système téléchargée", __FILE__);
 		} else {
-			$message = __("Vérification de l'intégrité de l'image système trouvée sur la cible", __FILE__);
+			$message = new Trad("Vérification de l'intégrité de l'image système trouvée sur la cible", __FILE__);
 		}
 		self::setProgress(['details' => $message, 'progress' => 95], 1);
 
@@ -253,23 +253,23 @@ class recovery {
 			if ($_downloaded) {
 				unlink($_filepath);
 			}
-			throw new Exception(__("Vérification annulée à la demande de l'utilisateur", __FILE__));
+			throw new Exception(new Trad("Vérification annulée à la demande de l'utilisateur", __FILE__));
 		}
 		if ($sha256 != $_sha256) {
 			unlink($_filepath);
-			throw new Exception(__("Erreur lors de la vérification de l'image système", __FILE__) . ' (' . $sha256 . ' != ' . $_sha256) . ')';
+			throw new Exception(new Trad("Erreur lors de la vérification de l'image système", __FILE__) . ' (' . $sha256 . ' != ' . $_sha256) . ')';
 		}
 	}
 
 	/** @return array|void */
 	private static function getImgInfos(string $_hardware) {
-		self::setProgress(['details' => __("Collecte des informations concernant l'image système", __FILE__) . ' ' . ucfirst($_hardware), 'progress' => 2], 1);
+		self::setProgress(['details' => new Trad("Collecte des informations concernant l'image système", __FILE__) . ' ' . ucfirst($_hardware), 'progress' => 2], 1);
 		$url = 'https://images.jeedom.com/';
 		$jsonUrl = $url . $_hardware . '/info.json';
 
 		$jsonContent = @file_get_contents($jsonUrl);
 		if ($jsonContent === false) {
-			throw new Exception(__("Impossible de récupérer les informations relatives aux images systèmes", __FILE__) . ' (' . $jsonUrl . ')');
+			throw new Exception(new Trad("Impossible de récupérer les informations relatives aux images systèmes", __FILE__) . ' (' . $jsonUrl . ')');
 		}
 
 		$imgInfos = json_decode($jsonContent, true);
@@ -282,19 +282,19 @@ class recovery {
 			return $imgInfos[$osVersion];
 		}
 
-		throw new Exception(__("Impossible de trouver les informations requises concernant l'image système", __FILE__) . ' ' . ucfirst($_hardware) .  ' ' . __('en version', __FILE__) . ' ' . $osVersion);
+		throw new Exception(new Trad("Impossible de trouver les informations requises concernant l'image système", __FILE__) . ' ' . ucfirst($_hardware) .  ' ' . new Trad('en version', __FILE__) . ' ' . $osVersion);
 	}
 
 	private static function prepareUsbDevice(string $_hardware, string $_mountPath = '/mnt/usb'): void {
-		self::setProgress(['details' => __('Vérification du périphérique USB', __FILE__), 'progress' => 3], 1);
+		self::setProgress(['details' => new Trad('Vérification du périphérique USB', __FILE__), 'progress' => 3], 1);
 		if (!$usbDevice = self::usbConnected($_hardware)) {
-			throw new Exception(__('Périphérique USB non détecté', __FILE__));
+			throw new Exception(new Trad('Périphérique USB non détecté', __FILE__));
 		}
 
 		$partition = $usbDevice . '1';
 		$fsType = trim(shell_exec('sudo blkid -s TYPE -o value ' . $partition));
 		if ($fsType !== 'vfat') {
-			throw new Exception(__("Le système de fichiers de la 1ère partition du périphérique USB n'est pas de type FAT", __FILE__) . ' (' . $fsType . ')');
+			throw new Exception(new Trad("Le système de fichiers de la 1ère partition du périphérique USB n'est pas de type FAT", __FILE__) . ' (' . $fsType . ')');
 		}
 
 		if (!file_exists($_mountPath)) {
@@ -304,15 +304,15 @@ class recovery {
 		}
 		exec('sudo mount -o rw,uid=www-data,gid=www-data ' . $partition . ' ' . $_mountPath, $output, $returnCode);
 		if ($returnCode !== 0 || empty(shell_exec('mount | grep ' . $_mountPath))) {
-			throw new Exception(__("Impossible d'accéder au périphérique USB, vérifier les logs http.error", __FILE__) . ' (' . $partition . ')');
+			throw new Exception(new Trad("Impossible d'accéder au périphérique USB, vérifier les logs http.error", __FILE__) . ' (' . $partition . ')');
 		}
 	}
 
 	private static function checkFreeSpace(string $_path, int $_imgSize = 1500000): void {
-		self::setProgress(['details' => __("Vérification de l'espace disque disponible", __FILE__), 'progress' => 4], 1);
+		self::setProgress(['details' => new Trad("Vérification de l'espace disque disponible", __FILE__), 'progress' => 4], 1);
 		$available = (int) trim(shell_exec("sudo df --output=avail -k $_path | tail -1"));
 		if ($available < $_imgSize) {
-			throw new Exception(__('Espace disque disponible insuffisant', __FILE__) . ' : ' . $available . 'Ko < ' . $_imgSize . 'Ko (' . $_path . ')');
+			throw new Exception(new Trad('Espace disque disponible insuffisant', __FILE__) . ' : ' . $available . 'Ko < ' . $_imgSize . 'Ko (' . $_path . ')');
 		}
 	}
 

--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -205,11 +205,11 @@ class scenario {
 			$scenarioGroupedList = array();
 			foreach ($scenarioListGroup as $group) {
 				$groupName = $group['group'];
-				if ($groupName == '') $groupName = __('Aucun', __FILE__);
+				if ($groupName == '') $groupName = new Trad('Aucun', __FILE__);
 				$scenarioGroupedList[$groupName] = array();
 				foreach ($scenarioList as $scenario) {
 					$scGroup = $scenario->getGroup();
-					if ($scGroup == '') $scGroup = __('Aucun', __FILE__);
+					if ($scGroup == '') $scGroup = new Trad('Aucun', __FILE__);
 					if ($scGroup != $groupName) continue;
 					array_push($scenarioGroupedList[$groupName], $scenario);
 				}
@@ -476,7 +476,7 @@ class scenario {
 		$scenario->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['startSubTask']['txt']);
 		if (isset($_options['tags']) && is_array($_options['tags']) && count($_options['tags']) > 0) {
 			$scenario->setTags($_options['tags']);
-			$scenario->setLog(__('Tags :', __FILE__) . ' ' . json_encode($scenario->getTags(), JSON_UNESCAPED_UNICODE));
+			$scenario->setLog(new Trad('Tags :', __FILE__) . ' ' . json_encode($scenario->getTags(), JSON_UNESCAPED_UNICODE));
 		}
 		if (!is_object($scenarioElement) || !is_object($scenario)) {
 			$scenario->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['toStartUnfound']['txt']);
@@ -535,7 +535,7 @@ class scenario {
 		$scenarios = self::all();
 		foreach ($scenarios as $scenario) {
 			if ($scenario->getGroup() == '') {
-				$group = __('Aucun', __FILE__);
+				$group = new Trad('Aucun', __FILE__);
 			} else {
 				$group = $scenario->getGroup();
 			}
@@ -556,11 +556,11 @@ class scenario {
 						if ($_needsReturn) {
 							$return[] = array(
 								'detail' => '<a href="/index.php?v=d&p=scenario&id=' . $scenario->getId() . '">' . $scenario->getHumanName() . '</a>',
-								'help' => __('Déclencheur', __FILE__),
+								'help' => new Trad('Déclencheur', __FILE__),
 								'who' => '#' . $cmd_id . '#'
 							);
 						} else {
-							log::add('scenario', 'error', __('Un déclencheur du scénario :', __FILE__) . ' ' . $scenario->getHumanName() . ' ' . __('est introuvable', __FILE__));
+							log::add('scenario', 'error', new Trad('Un déclencheur du scénario :', __FILE__) . ' ' . $scenario->getHumanName() . ' ' . new Trad('est introuvable', __FILE__));
 						}
 					}
 				}
@@ -577,11 +577,11 @@ class scenario {
 					if ($_needsReturn) {
 						$return[] = array(
 							'detail' => '<a href="/index.php?v=d&p=scenario&id=' . $scenario->getId() . '">' . $scenario->getHumanName() . '</a>',
-							'help' => __('Expression', __FILE__),
+							'help' => new Trad('Expression', __FILE__),
 							'who' => '#' . $cmd_id . '#'
 						);
 					} else {
-						log::add('scenario', 'error', __('Une commande du scénario :', __FILE__) . ' ' . $scenario->getHumanName() . ' ' . __('est introuvable', __FILE__));
+						log::add('scenario', 'error', new Trad('Une commande du scénario :', __FILE__) . ' ' . $scenario->getHumanName() . ' ' . new Trad('est introuvable', __FILE__));
 					}
 				}
 			}
@@ -602,8 +602,8 @@ class scenario {
 			'scenario_name' => html_entity_decode($_scenario_name),
 		);
 
-		if ($_object_name == __('Aucun', __FILE__)) {
-			if ($_group_name == __('Aucun', __FILE__)) {
+		if ($_object_name == new Trad('Aucun', __FILE__)) {
+			if ($_group_name == new Trad('Aucun', __FILE__)) {
 				$sql = 'SELECT ' . DB::buildField(__CLASS__, 's') . '
 				FROM scenario s
 				WHERE s.name=:scenario_name
@@ -619,7 +619,7 @@ class scenario {
 			}
 		} else {
 			$values['object_name'] = $_object_name;
-			if ($_group_name == __('Aucun', __FILE__)) {
+			if ($_group_name == new Trad('Aucun', __FILE__)) {
 				$sql = 'SELECT ' . DB::buildField(__CLASS__, 's') . '
 				FROM scenario s
 				INNER JOIN object ob ON s.object_id=ob.id
@@ -841,8 +841,8 @@ class scenario {
 		if ($state == 'starting') {
 			//Scenario stuck into starting state. May be too much sql connections, refused connection, or scenario hangs.
 			if (strtotime('now') - $this->getCache('startingTime') > 5) {
-				log::add('scenario', 'error', __('La dernière exécution du scénario ne s\'est pas lancée. Vérifiez le log scenario_execution, ainsi que le log du scénario', __FILE__) . " \"" . $this->getName() . "\".");
-				$this->setLog(__('La dernière exécution du scénario ne s\'est pas lancée. Vérifiez le log scenario_execution pour l\'exécution à', __FILE__) . ' ' . date('Y-m-d H:i:s', $this->getCache('startingTime')) . ".");
+				log::add('scenario', 'error', new Trad('La dernière exécution du scénario ne s\'est pas lancée. Vérifiez le log scenario_execution, ainsi que le log du scénario', __FILE__) . " \"" . $this->getName() . "\".");
+				$this->setLog(new Trad('La dernière exécution du scénario ne s\'est pas lancée. Vérifiez le log scenario_execution pour l\'exécution à', __FILE__) . ' ' . date('Y-m-d H:i:s', $this->getCache('startingTime')) . ".");
 				$this->persistLog();
 			}
 			//Delay scenario start if another instance ever starting.
@@ -857,8 +857,8 @@ class scenario {
 					}
 				}
 				if ($state == 'starting') {
-					log::add('scenario', 'error', __('Trop d\'appels simultanés du scénario, il ne peut-être exécuté une nouvelle fois. Il est conseillé de réduire les appels au scénario', __FILE__) . " \"" . $this->getName() . "\".");
-					$this->setLog(__('Trop d\'appels simultanés du scénario, il ne peut-être exécuté une nouvelle fois. Il est conseillé de réduire les appels à ce scénario', __FILE__) . ".");
+					log::add('scenario', 'error', new Trad('Trop d\'appels simultanés du scénario, il ne peut-être exécuté une nouvelle fois. Il est conseillé de réduire les appels au scénario', __FILE__) . " \"" . $this->getName() . "\".");
+					$this->setLog(new Trad('Trop d\'appels simultanés du scénario, il ne peut-être exécuté une nouvelle fois. Il est conseillé de réduire les appels à ce scénario', __FILE__) . ".");
 					$this->persistLog();
 					return false;
 				}
@@ -897,7 +897,7 @@ class scenario {
 			cache::byKey('scenarioInstanceAttr'.$this->getId().'::'.$instance_id)->remove();
 		}
 		if ($this->getIsActive() != 1) {
-			$this->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['disableScenario']['txt']  . $this->getHumanName() . ' ' . __('sur :', __FILE__) . ' ' . $this->getTag('message') . ' ' . __('car il est désactivé', __FILE__));
+			$this->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['disableScenario']['txt']  . $this->getHumanName() . ' ' . new Trad('sur :', __FILE__) . ' ' . $this->getTag('message') . ' ' . new Trad('car il est désactivé', __FILE__));
 			$this->setState('stop');
 			$this->setPID();
 			$this->persistLog();
@@ -905,7 +905,7 @@ class scenario {
 		}
 		if ($this->getConfiguration('timeDependency', 0) == 1) {
 			if (!jeedom::isDateOk() || (((new DateTime('today midnight +1 day'))->format('I') - (new DateTime('today midnight'))->format('I')) == -1  && date('I') == 1 && date('Gi') > 159)) {
-				$this->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $this->getHumanName() . ' ' . __('annulé car il utilise une condition de type temporelle et que la date système n\'est pas OK (ou que l\'on est en changement d\'heure négatif)', __FILE__));
+				$this->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $this->getHumanName() . ' ' . new Trad('annulé car il utilise une condition de type temporelle et que la date système n\'est pas OK (ou que l\'on est en changement d\'heure négatif)', __FILE__));
 				$this->setState('stop');
 				$this->setPID();
 				$this->persistLog();
@@ -914,7 +914,7 @@ class scenario {
 		}
 		$cmd = cmd::byId(str_replace('#', '', $this->getTag('trigger_id')));
 		if (is_object($cmd)) {
-			log::add('event', 'info', __('Exécution du scénario', __FILE__) . ' ' . $this->getHumanName() . ' ' . __('déclenché par :', __FILE__) . ' ' . $cmd->getHumanName());
+			log::add('event', 'info', new Trad('Exécution du scénario', __FILE__) . ' ' . $this->getHumanName() . ' ' . new Trad('déclenché par :', __FILE__) . ' ' . $cmd->getHumanName());
 			if ($this->getConfiguration('timeline::enable')) {
 				$timeline = new timeline();
 				$timeline->setType('scenario');
@@ -925,7 +925,7 @@ class scenario {
 				$timeline->save();
 			}
 		} else {
-			log::add('event', 'info', __('Exécution du scénario', __FILE__) . ' ' . $this->getHumanName() . ' ' . __('déclenché par :', __FILE__) . ' ' . $this->getTag('trigger'));
+			log::add('event', 'info', new Trad('Exécution du scénario', __FILE__) . ' ' . $this->getHumanName() . ' ' . new Trad('déclenché par :', __FILE__) . ' ' . $this->getTag('trigger'));
 			if ($this->getConfiguration('timeline::enable')) {
 				$timeline = new timeline();
 				$timeline->setType('scenario');
@@ -1082,7 +1082,7 @@ class scenario {
 			throw new Exception('Le nom du scénario ne peut pas être vide.');
 		}
 		if (($this->getMode() == 'schedule' || $this->getMode() == 'all') && $this->getSchedule() == '') {
-			throw new Exception(__('Le scénario est de type programmé mais la programmation est vide', __FILE__));
+			throw new Exception(new Trad('Le scénario est de type programmé mais la programmation est vide', __FILE__));
 		}
 		if ($this->getConfiguration('has_return', 0) == 1) {
 			$this->setConfiguration('syncmode', 1);
@@ -1273,7 +1273,7 @@ class scenario {
 						$cron->halt();
 						$cron->remove();
 					} catch (Exception $e) {
-						log::add('scenario', 'info', __('Impossible d\'arrêter la sous tâche :', __FILE__) . ' ' . json_encode($cron->getOption(), JSON_UNESCAPED_UNICODE));
+						log::add('scenario', 'info', new Trad('Impossible d\'arrêter la sous tâche :', __FILE__) . ' ' . json_encode($cron->getOption(), JSON_UNESCAPED_UNICODE));
 					}
 				}
 			}
@@ -1298,7 +1298,7 @@ class scenario {
 				}
 			}
 			if ($this->running()) {
-				throw new Exception(__('Impossible d\'arrêter le scénario :', __FILE__) . ' ' . $this->getHumanName() . '. ' . __('PID :', __FILE__) . ' ' . $this->getPID());
+				throw new Exception(new Trad('Impossible d\'arrêter le scénario :', __FILE__) . ' ' . $this->getHumanName() . '. ' . new Trad('PID :', __FILE__) . ' ' . $this->getPID());
 			}
 		}
 		$this->setState('stop');
@@ -1451,7 +1451,7 @@ class scenario {
 		//$_tag: html label with custom color
 		$name = '';
 		if (!$_noGroup) {
-			$groupName = $this->getGroup() != '' ? $this->getGroup() : __('Aucun', __FILE__);
+			$groupName = $this->getGroup() != '' ? $this->getGroup() : new Trad('Aucun', __FILE__);
 			if ($_tag) {
 				$name .= '<span class="label label-info">' . $groupName . '</span> ';
 			} else {
@@ -1472,9 +1472,9 @@ class scenario {
 		} else {
 			if ($_complete) {
 				if ($_tag) {
-					$name .= '<span class="label labelObjectHuman">' . __('Aucun', __FILE__) . '</span>';
+					$name .= '<span class="label labelObjectHuman">' . new Trad('Aucun', __FILE__) . '</span>';
 				} else {
-					$name .= '[' . __('Aucun', __FILE__) . ']';
+					$name .= '[' . new Trad('Aucun', __FILE__) . ']';
 				}
 			}
 		}
@@ -1564,7 +1564,7 @@ class scenario {
 		$_data['node']['scenario' . $this->getId()] = array(
 			'id' => 'scenario' . $this->getId(),
 			'name' => $this->getName(),
-			'type' => __('Scénario', __FILE__),
+			'type' => new Trad('Scénario', __FILE__),
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
 			'shape' => 'rect',
 			'width' => 40,

--- a/core/class/scenarioElement.class.php
+++ b/core/class/scenarioElement.class.php
@@ -49,7 +49,7 @@ class scenarioElement {
 			$element_db = new scenarioElement();
 		}
 		if (!isset($element_db) || !is_object($element_db)) {
-			throw new Exception(__('Elément inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . $element_ajax['id']);
+			throw new Exception(new Trad('Elément inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . $element_ajax['id']);
 		}
 		utils::a2o($element_db, $element_ajax);
 		$element_db->save();
@@ -63,7 +63,7 @@ class scenarioElement {
 				$subElement_db = new scenarioSubElement();
 			}
 			if (!isset($subElement_db) || !is_object($subElement_db)) {
-				throw new Exception(__('Sous-élément inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . $subElement_ajax['id']);
+				throw new Exception(new Trad('Sous-élément inconnu. Vérifiez l\'ID :', __FILE__) . ' ' . $subElement_ajax['id']);
 			}
 			utils::a2o($subElement_db, $subElement_ajax);
 			$subElement_db->setScenarioElement_id($element_db->getId());
@@ -85,7 +85,7 @@ class scenarioElement {
 					$expression_db = new scenarioExpression();
 				}
 				if (!isset($expression_db) || !is_object($expression_db)) {
-					throw new Exception(__('Expression inconnue. Vérifiez l\'ID :', __FILE__) . ' ' . $expression_ajax['id']);
+					throw new Exception(new Trad('Expression inconnue. Vérifiez l\'ID :', __FILE__) . ' ' . $expression_ajax['id']);
 				}
 				$expression_db->emptyOptions();
 				utils::a2o($expression_db, $expression_ajax);
@@ -153,8 +153,8 @@ class scenarioElement {
 						$expresssion_str = $expression->getExpression();
 					}
 				}
-				$message = __('Expression non valide', __FILE__) . '  [' . $expresssion_str . '] ' . __('trouvée dans le scénario :', __FILE__) . ' ' . $_scenario->getHumanName() . __(', résultat : ', __FILE__) . $result;
-				$action = '<a href="/' . $_scenario->getLinkToConfiguration() . '">' . __('Scenario', __FILE__) . '</a>';
+				$message = new Trad('Expression non valide', __FILE__) . '  [' . $expresssion_str . '] ' . new Trad('trouvée dans le scénario :', __FILE__) . ' ' . $_scenario->getHumanName() . new Trad(', résultat : ', __FILE__) . $result;
+				$action = '<a href="/' . $_scenario->getLinkToConfiguration() . '">' . new Trad('Scenario', __FILE__) . '</a>';
 				$logicalId = 'invalidExprScenarioElement::' . $this->getId();
 				message::add('scenario', $message, $action, $logicalId);
 				return;
@@ -165,7 +165,7 @@ class scenarioElement {
 						$this->getSubElement('if')->setOptions('previousState', 1);
 						$this->getSubElement('if')->save();
 					} else {
-						$_scenario->setLog(__('Non exécution des actions pour cause de répétition', __FILE__));
+						$_scenario->setLog(new Trad('Non exécution des actions pour cause de répétition', __FILE__));
 						return;
 					}
 				}
@@ -179,7 +179,7 @@ class scenarioElement {
 					$this->getSubElement('if')->setOptions('previousState', 0);
 					$this->getSubElement('if')->save();
 				} else {
-					$_scenario->setLog(__('Non exécution des actions pour cause de répétition', __FILE__));
+					$_scenario->setLog(new Trad('Non exécution des actions pour cause de répétition', __FILE__));
 					return;
 				}
 			}
@@ -200,7 +200,7 @@ class scenarioElement {
 			}
 			$limits = intval($this->getSubElement('for')->execute($_scenario));
 			if (!is_numeric($limits)) {
-				throw new Exception(__('La condition pour une boucle doit être numérique :', __FILE__) . ' ' . $limits);
+				throw new Exception(new Trad('La condition pour une boucle doit être numérique :', __FILE__) . ' ' . $limits);
 			}
 			$return = false;
 			for ($i = 1; $i <= $limits; $i++) {
@@ -250,7 +250,7 @@ class scenarioElement {
 			}
 			$next = $this->getSubElement('at')->execute($_scenario);
 			if (!is_numeric($next) || $next < 0) {
-				throw new Exception(__('Bloc type A :', __FILE__) . ' ' . $this->getId() . $GLOBALS['JEEDOM_SCLOG_TEXT']['invalideShedule']['txt'] . $next);
+				throw new Exception(new Trad('Bloc type A :', __FILE__) . ' ' . $this->getId() . $GLOBALS['JEEDOM_SCLOG_TEXT']['invalideShedule']['txt'] . $next);
 			}
 			if ($next <= date('Gi')) {
 				$next = str_repeat('0', 4 - strlen($next)) . $next;
@@ -261,7 +261,7 @@ class scenarioElement {
 			}
 			$next = strtotime($next);
 			if ($next < strtotime('now')) {
-				throw new Exception(__('Bloc type A :', __FILE__) . ' ' . $this->getId() . $GLOBALS['JEEDOM_SCLOG_TEXT']['invalideShedule']['txt'] . date('Y-m-d H:i:00', $next));
+				throw new Exception(new Trad('Bloc type A :', __FILE__) . ' ' . $this->getId() . $GLOBALS['JEEDOM_SCLOG_TEXT']['invalideShedule']['txt'] . date('Y-m-d H:i:00', $next));
 			}
 			$crons = cron::searchClassAndFunction('scenario', 'doIn', '"scenarioElement_id":' . $this->getId() . ',');
 			if (is_array($crons)) {
@@ -411,31 +411,31 @@ class scenarioElement {
 			$return .= "\n";
 			switch ($subElement->getType()) {
 				case 'if':
-					$return .= __('SI', __FILE__);
+					$return .= new Trad('SI', __FILE__);
 					break;
 				case 'then':
-					$return .= __('ALORS', __FILE__);
+					$return .= new Trad('ALORS', __FILE__);
 					break;
 				case 'else':
-					$return .= __('SINON', __FILE__);
+					$return .= new Trad('SINON', __FILE__);
 					break;
 				case 'for':
-					$return .= __('POUR', __FILE__);
+					$return .= new Trad('POUR', __FILE__);
 					break;
 				case 'do':
-					$return .= __('FAIRE', __FILE__);
+					$return .= new Trad('FAIRE', __FILE__);
 					break;
 				case 'code':
-					$return .= __('CODE', __FILE__);
+					$return .= new Trad('CODE', __FILE__);
 					break;
 				case 'action':
-					$return .= __('ACTION', __FILE__);
+					$return .= new Trad('ACTION', __FILE__);
 					break;
 				case 'in':
-					$return .= __('DANS', __FILE__);
+					$return .= new Trad('DANS', __FILE__);
 					break;
 				case 'at':
-					$return .= __('A', __FILE__);
+					$return .= new Trad('A', __FILE__);
 					break;
 				default:
 					$return .= $subElement->getType();

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1855,8 +1855,8 @@ class scenarioExpression {
 							break;
 						case 'eqAnalyse':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options));
@@ -1865,8 +1865,8 @@ class scenarioExpression {
 							break;
 						case 'eqAnalyseAlert':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$options['tab'] = 'alertEqlogic';
@@ -1876,8 +1876,8 @@ class scenarioExpression {
 							break;
 						case 'health':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=health&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'health', $options['export_type'], $options));
@@ -1886,8 +1886,8 @@ class scenarioExpression {
 							break;
 						case 'timeline':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=timeline&report=1&timeline=' . $options['timeline'];
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport timeline', __FILE__) . ' ' . $options['timeline']);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'timeline', $options['export_type'], $options));

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -132,26 +132,26 @@ class scenarioExpression {
 				$name = $scenario->getName();
 			}
 			$action = $_action['options']['action'];
-			$return .= '<b>' . __('Scénario', __FILE__) . '</b> : ' . $name . ' <i class="fas fa-arrow-right"></i> ' . $action;
+			$return .= '<b>' . new Trad('Scénario', __FILE__) . '</b> : ' . $name . ' <i class="fas fa-arrow-right"></i> ' . $action;
 		} elseif ($_action['cmd'] == 'variable') {
 			$name = $_action['options']['name'];
 			$value = $_action['options']['value'];
-			$return .= '<b>' . __('Variable', __FILE__) . '</b> : ' . $name . ' <i class="fas fa-arrow-right"></i> ' . $value;
+			$return .= '<b>' . new Trad('Variable', __FILE__) . '</b> : ' . $name . ' <i class="fas fa-arrow-right"></i> ' . $value;
 		} elseif ($_action['cmd'] == 'equipement') {
 			$name = eqLogic::toHumanReadable($_action['options']['eqLogic']);
 			$action = $_action['options']['action'];
 			switch ($_action['options']['action']) {
 				case 'activate':
-					$action = __('Activation de', __FILE__);
+					$action = new Trad('Activation de', __FILE__);
 					break;
 				case 'deactivate':
-					$action = __('Désactivation de', __FILE__);
+					$action = new Trad('Désactivation de', __FILE__);
 					break;
 				case 'hide':
-					$action = __('Masquage de', __FILE__);
+					$action = new Trad('Masquage de', __FILE__);
 					break;
 				case 'show':
-					$action = __('Affichage de', __FILE__);
+					$action = new Trad('Affichage de', __FILE__);
 					break;
 			}
 			$return .= $action . ' : ' . $name;
@@ -162,7 +162,7 @@ class scenarioExpression {
 			if (is_object($object)) {
 				$objectName = $object->getHumanName(true, true); //$object->getDisplay('icon').' '.$object->getName();
 			} else {
-				$objectName = '<span class="label labelObjectHuman">' . __('Aucun', __FILE__) . '</span>';
+				$objectName = '<span class="label labelObjectHuman">' . new Trad('Aucun', __FILE__) . '</span>';
 			}
 			$return .= $objectName . ' ' . $eqLogic->getName() . ' <i class="fas fa-arrow-right"></i> ' . $cmd->getName();
 		} elseif ($_action['cmd'] != '') {
@@ -1130,11 +1130,11 @@ class scenarioExpression {
 			case 'object':
 				$object = $cmd->getEqLogic()->getObject();
 				if (!is_object($object)) {
-					return __('Aucun', __FILE__);
+					return new Trad('Aucun', __FILE__);
 				}
 				return $object->getName();
 		}
-		return __('Type inconnu', __FILE__);
+		return new Trad('Type inconnu', __FILE__);
 	}
 
 	public static function getRequestTags($_expression) {
@@ -1390,7 +1390,7 @@ class scenarioExpression {
 			cache::set($key, array('scenarioExpression' => $this, 'scenario' => $scenario), 60);
 			$cmd = __DIR__ . '/../php/jeeScenarioExpression.php';
 			$cmd .= ' key=' . $key;
-			$this->setLog($scenario, __('Execution du lancement en arriere plan :', __FILE__) . ' ' . $key);
+			$this->setLog($scenario, new Trad('Execution du lancement en arriere plan :', __FILE__) . ' ' . $key);
 			system::php($cmd . ' >> /dev/null 2>&1 &');
 			return;
 		}
@@ -1399,7 +1399,7 @@ class scenarioExpression {
 			if ($this->getType() == 'element') {
 				$element = scenarioElement::byId($this->getExpression());
 				if (is_object($element)) {
-					$this->setLog($scenario, __('Exécution d\'un bloc élément :', __FILE__) . ' ' . $this->getExpression());
+					$this->setLog($scenario, new Trad('Exécution d\'un bloc élément :', __FILE__) . ' ' . $this->getExpression());
 					return $element->execute($scenario);
 				}
 				return;
@@ -1422,7 +1422,7 @@ class scenarioExpression {
 				if ($this->getExpression() == 'icon') {
 					if ($scenario !== null) {
 						$options = $this->getOptions();
-						$this->setLog($scenario, __('Changement de l\'icone du scénario :', __FILE__) . ' ' . $options['icon']);
+						$this->setLog($scenario, new Trad('Changement de l\'icone du scénario :', __FILE__) . ' ' . $options['icon']);
 						$scenario->setDisplay('icon', $options['icon']);
 						$scenario->save();
 					}
@@ -1442,13 +1442,13 @@ class scenarioExpression {
 						$expression = self::setTags($options['condition'], $scenario, true);
 						$result = evaluate($expression);
 						if ($occurence > $limit) {
-							$this->setLog($scenario, __('[Wait] Condition valide par dépassement de temps :', __FILE__) . ' ' . $expression . ' => ' . $result);
+							$this->setLog($scenario, new Trad('[Wait] Condition valide par dépassement de temps :', __FILE__) . ' ' . $expression . ' => ' . $result);
 							return;
 						}
 						$occurence++;
 						sleep(1);
 					}
-					$this->setLog($scenario, __('[Wait] Condition valide :', __FILE__) . ' ' . $expression . ' => ' . $result);
+					$this->setLog($scenario, new Trad('[Wait] Condition valide :', __FILE__) . ' ' . $expression . ' => ' . $result);
 					return;
 				} elseif ($this->getExpression() == 'sleep') {
 					if (isset($options['duration'])) {
@@ -1458,7 +1458,7 @@ class scenarioExpression {
 						} catch (Error $e) {
 						}
 						if ((is_float($options['duration']) || is_int($options['duration'])) && $options['duration'] > 0) {
-							$this->setLog($scenario, __('Pause de', __FILE__) . ' ' . $options['duration'] . ' ' . __('seconde(s)', __FILE__));
+							$this->setLog($scenario, new Trad('Pause de', __FILE__) . ' ' . $options['duration'] . ' ' . new Trad('seconde(s)', __FILE__));
 							if ($options['duration'] < 1) {
 								usleep($options['duration'] * 1000000);
 								return;
@@ -1471,7 +1471,7 @@ class scenarioExpression {
 					return;
 				} elseif ($this->getExpression() == 'stop') {
 					if ($scenario !== null) {
-						$this->setLog($scenario, __('Action stop', __FILE__));
+						$this->setLog($scenario, new Trad('Action stop', __FILE__));
 						$scenario->setDo(false);
 						return;
 					}
@@ -1487,7 +1487,7 @@ class scenarioExpression {
 						throw new Exception($GLOBALS['JEEDOM_SCLOG_TEXT']['unfoundCmd']['txt'] . $options['cmd']);
 					}
 					$cmd->event(jeedom::evaluateExpression($options['value']));
-					$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['event']['txt'] . $cmd->getHumanName() . ' ' . __('à', __FILE__) . ' ' . $options['value']);
+					$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['event']['txt'] . $cmd->getHumanName() . ' ' . new Trad('à', __FILE__) . ' ' . $options['value']);
 					return;
 				} elseif ($this->getExpression() == 'message') {
 					$source = 'scenario';
@@ -1497,15 +1497,15 @@ class scenarioExpression {
 						$source = 'Scenario ' . $scenario->getHumanName();
 					}
 					message::add($source, $options['message']);
-					$this->setLog($scenario, __('Ajout du message suivant dans le centre de message :', __FILE__) . ' ' . $options['message']);
+					$this->setLog($scenario, new Trad('Ajout du message suivant dans le centre de message :', __FILE__) . ' ' . $options['message']);
 					return;
 				} elseif ($this->getExpression() == 'alert') {
 					event::add('jeedom::alert', $options);
-					$this->setLog($scenario, __('Ajout de l\'alerte :', __FILE__) . ' ' . $options['message']);
+					$this->setLog($scenario, new Trad('Ajout de l\'alerte :', __FILE__) . ' ' . $options['message']);
 					return;
 				} elseif ($this->getExpression() == 'popup') {
 					event::add('jeedom::alertPopup', $options['message']);
-					$this->setLog($scenario, __('Affichage du popup :', __FILE__) . ' ' . $options['message']);
+					$this->setLog($scenario, new Trad('Affichage du popup :', __FILE__) . ' ' . $options['message']);
 					return;
 				} elseif ($this->getExpression() == 'setColoredIcon') {
 					config::save('interface::advance::coloredIcons', $options['state']);
@@ -1517,33 +1517,33 @@ class scenarioExpression {
 					}
 					switch ($this->getOptions('action')) {
 						case 'show':
-							$this->setLog($scenario, __('Equipement visible :', __FILE__) . ' ' . $eqLogic->getHumanName());
+							$this->setLog($scenario, new Trad('Equipement visible :', __FILE__) . ' ' . $eqLogic->getHumanName());
 							$eqLogic->setIsVisible(1);
 							$eqLogic->save();
 							break;
 						case 'hide':
-							$this->setLog($scenario, __('Equipement masqué :', __FILE__) . ' ' . $eqLogic->getHumanName());
+							$this->setLog($scenario, new Trad('Equipement masqué :', __FILE__) . ' ' . $eqLogic->getHumanName());
 							$eqLogic->setIsVisible(0);
 							$eqLogic->save();
 							break;
 						case 'deactivate':
-							$this->setLog($scenario, __('Equipement désactivé :', __FILE__) . ' ' . $eqLogic->getHumanName());
+							$this->setLog($scenario, new Trad('Equipement désactivé :', __FILE__) . ' ' . $eqLogic->getHumanName());
 							$eqLogic->setIsEnable(0);
 							$eqLogic->save();
 							break;
 						case 'activate':
-							$this->setLog($scenario, __('Equipement activé :', __FILE__) . ' ' . $eqLogic->getHumanName());
+							$this->setLog($scenario, new Trad('Equipement activé :', __FILE__) . ' ' . $eqLogic->getHumanName());
 							$eqLogic->setIsEnable(1);
 							$eqLogic->save();
 							break;
 					}
 					return;
 				} elseif ($this->getExpression() == 'gotodesign') {
-					$this->setLog($scenario, __('Changement design :', __FILE__) . ' ' . $options['plan_id']);
+					$this->setLog($scenario, new Trad('Changement design :', __FILE__) . ' ' . $options['plan_id']);
 					event::add('jeedom::gotoplan', $options['plan_id']);
 					return;
 				} elseif ($this->getExpression() == 'changeTheme') {
-					$this->setLog($scenario, __('Changement de thème :', __FILE__) . ' ' . $options['theme']);
+					$this->setLog($scenario, new Trad('Changement de thème :', __FILE__) . ' ' . $options['theme']);
 					event::add('changeTheme', $options['theme']);
 					return;
 				} elseif ($this->getExpression() == 'scenario') {
@@ -1569,7 +1569,7 @@ class scenarioExpression {
 							if (is_array($this->getOptions('tags'))) {
 								$actionScenario->setTags($this->getOptions('tags'));
 							}
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
+							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . new Trad('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
 							if ($scenario !== null) {
 								$actionScenario->addTag('trigger','scenario');
 								$actionScenario->addTag('trigger_message',$GLOBALS['JEEDOM_SCLOG_TEXT']['startByScenario']['txt'] . $scenario->getHumanName());
@@ -1595,7 +1595,7 @@ class scenarioExpression {
 							if (is_array($this->getOptions('tags'))) {
 								$actionScenario->setTags($this->getOptions('tags'));
 							}
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
+							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . new Trad('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
 							if ($scenario !== null) {
 								$actionScenario->addTag('trigger','scenario');
 								$actionScenario->addTag('trigger_message',$GLOBALS['JEEDOM_SCLOG_TEXT']['startByScenario']['txt'] . $scenario->getHumanName());
@@ -1609,22 +1609,22 @@ class scenarioExpression {
 							}
 							break;
 						case 'stop':
-							$this->setLog($scenario, __('Arrêt forcé du scénario :', __FILE__) . ' ' . $actionScenario->getName());
+							$this->setLog($scenario, new Trad('Arrêt forcé du scénario :', __FILE__) . ' ' . $actionScenario->getName());
 							$actionScenario->stop();
 							break;
 						case 'deactivate':
-							$this->setLog($scenario, __('Désactivation du scénario :', __FILE__) . ' ' . $actionScenario->getName());
+							$this->setLog($scenario, new Trad('Désactivation du scénario :', __FILE__) . ' ' . $actionScenario->getName());
 							$actionScenario->setIsActive(0);
 							$actionScenario->save();
 							break;
 						case 'activate':
-							$this->setLog($scenario, __('Activation du scénario :', __FILE__) . ' ' . $actionScenario->getName());
+							$this->setLog($scenario, new Trad('Activation du scénario :', __FILE__) . ' ' . $actionScenario->getName());
 							$actionScenario->setLastLaunch(date('Y-m-d H:i:s'));
 							$actionScenario->setIsActive(1);
 							$actionScenario->save();
 							break;
 						case 'resetRepeatIfStatus':
-							$this->setLog($scenario, __('Remise à zéro des statuts des SI du scénario :', __FILE__) . ' ' . $actionScenario->getName());
+							$this->setLog($scenario, new Trad('Remise à zéro des statuts des SI du scénario :', __FILE__) . ' ' . $actionScenario->getName());
 							$actionScenario->resetRepeatIfStatus();
 							break;
 					}
@@ -1640,7 +1640,7 @@ class scenarioExpression {
 					} catch (Error $ex) {
 						$result = $options['value'];
 					}
-					$this->setLog($scenario, __('Affectation de la variable', __FILE__) . ' ' . $this->getOptions('name') . ' => ' . $result . ' (' . $options['value'] . ')');
+					$this->setLog($scenario, new Trad('Affectation de la variable', __FILE__) . ' ' . $this->getOptions('name') . ' => ' . $result . ' (' . $options['value'] . ')');
 					$dataStore = new dataStore();
 					$dataStore->setKey($this->getOptions('name'));
 					$dataStore->setValue($result);
@@ -1654,7 +1654,7 @@ class scenarioExpression {
 						foreach ($cmds as $cmd) {
 							if ($cmd->getType() == 'info') {
 								$cmd->event(jeedom::evaluateExpression($options['value']));
-								$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['event']['txt'] . $cmd->getHumanName() . ' ' . __('à', __FILE__) . ' ' . $options['value']);
+								$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['event']['txt'] . $cmd->getHumanName() . ' ' . new Trad('à', __FILE__) . ' ' . $options['value']);
 							} else if ($cmd->getType() == 'action' && $cmd->getEqLogic()->getIsEnable() == 1) {
 								if ($cmd->getSubtype() == 'slider') {
 									$options['slider'] = evaluate($options['value']);
@@ -1662,7 +1662,7 @@ class scenarioExpression {
 								$cmd->execCmd($options);
 								$log = $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $cmd->getHumanName();
 								if ($options['value'] != '') {
-									$log .= ' ' . __('à', __FILE__) . ' ' . $options['value'];
+									$log .= ' ' . new Trad('à', __FILE__) . ' ' . $options['value'];
 								}
 								$this->setLog($scenario, $log);
 							}
@@ -1675,7 +1675,7 @@ class scenarioExpression {
 					}
 				} elseif ($this->getExpression() == 'delete_variable') {
 					$scenario->removeData($options['name']);
-					$this->setLog($scenario, __('Suppression de la variable', __FILE__) . ' ' . $options['name']);
+					$this->setLog($scenario, new Trad('Suppression de la variable', __FILE__) . ' ' . $options['name']);
 					return;
 				} elseif ($this->getExpression() == 'ask') {
 					$dataStore = new dataStore();
@@ -1705,7 +1705,7 @@ class scenarioExpression {
 					if (!is_object($cmd)) {
 						throw new Exception($GLOBALS['JEEDOM_SCLOG_TEXT']['unfoundCmdCheckId']['txt'] . $this->getOptions('cmd'));
 					}
-					$this->setLog($scenario, __('Demande', __FILE__) . ' ' . json_encode($options_cmd));
+					$this->setLog($scenario, new Trad('Demande', __FILE__) . ' ' . json_encode($options_cmd));
 					$cmd->setCache('ask::variable', $options['variable']);
 					$cmd->setCache('ask::endtime', strtotime('now') + $limit);
 					$cmd->setCache('ask::answer', explode(';', $options['answer']));
@@ -1727,35 +1727,35 @@ class scenarioExpression {
 						sleep(1);
 					}
 					if ($value == '') {
-						$value = __('Aucune réponse', __FILE__);
+						$value = new Trad('Aucune réponse', __FILE__);
 						$cmd->setCache('ask::variable', 'none');
 						$dataStore = dataStore::byTypeLinkIdKey('scenario', -1, $options['variable']);
 						$dataStore->setValue($value);
 						$dataStore->save();
 					}
 					event::add('scenario::ask', array('scenario_id' => $scenario->getId(), 'variable' => $options['variable'], 'value' => $value));
-					$this->setLog($scenario, __('Réponse', __FILE__) . ' ' . $value);
+					$this->setLog($scenario, new Trad('Réponse', __FILE__) . ' ' . $value);
 					return;
 				} elseif ($this->getExpression() == 'jeedom_poweroff') {
 					if (is_object($scenario)) {
-						$this->setLog($scenario, __('Lancement de l\'arret de jeedom', __FILE__));
+						$this->setLog($scenario, new Trad('Lancement de l\'arret de jeedom', __FILE__));
 						$scenario->persistLog();
 					} else {
-						log::add('cmd', 'info', __('Lancement de l\'arret de jeedom', __FILE__));
+						log::add('cmd', 'info', new Trad('Lancement de l\'arret de jeedom', __FILE__));
 					}
 					jeedom::haltSystem();
 					return;
 				} elseif ($this->getExpression() == 'jeedom_reboot') {
 					if (is_object($scenario)) {
-						$this->setLog($scenario, __('Lancement du reboot de jeedom', __FILE__));
+						$this->setLog($scenario, new Trad('Lancement du reboot de jeedom', __FILE__));
 						$scenario->persistLog();
 					} else {
-						log::add('cmd', 'info', __('Lancement du reboot de jeedom', __FILE__));
+						log::add('cmd', 'info', new Trad('Lancement du reboot de jeedom', __FILE__));
 					}
 					jeedom::rebootSystem();
 					return;
 				} elseif ($this->getExpression() == 'scenario_return') {
-					$this->setLog($scenario, __('Demande de retour d\'information :', __FILE__) . ' ' . $options['message']);
+					$this->setLog($scenario, new Trad('Demande de retour d\'information :', __FILE__) . ' ' . $options['message']);
 					if ($scenario->getReturn() === true) {
 						$scenario->setReturn($options['message']);
 					} else {
@@ -1772,7 +1772,7 @@ class scenarioExpression {
 					if ($scenario === null) {
 						return;
 					}
-					$this->setLog($scenario, __('Suppression des blocs DANS et A programmés du scénario', __FILE__) . ' ');
+					$this->setLog($scenario, new Trad('Suppression des blocs DANS et A programmés du scénario', __FILE__) . ' ');
 					$crons = cron::searchClassAndFunction('scenario', 'doIn', '"scenario_id":' . $scenario->getId() . ',');
 					if (is_array($crons)) {
 						foreach ($crons as $cron) {
@@ -1785,7 +1785,7 @@ class scenarioExpression {
 					return;
 				} elseif ($this->getExpression() == 'exportHistory') {
 					if (!isset($options['name']) || trim($options['name']) == '') {
-						$options['name'] = __('Export historique', __FILE__);
+						$options['name'] = new Trad('Export historique', __FILE__);
 					}
 					$options['name'] = str_replace(array('/'), array(''), $options['name']);
 					$tmp_file = jeedom::getTmpFolder('history_export') . '/' . $options['name'] . '.csv';
@@ -1793,7 +1793,7 @@ class scenarioExpression {
 
 					$start = date('Y-m-d H:i:s',(int) strtotime($options['start']));
 					$end = date('Y-m-d H:i:s',(int) strtotime($options['end']));
-					$this->setLog($scenario, __('Export de l\'historique du', __FILE__) . ' ' . $start . ' ' . __('au', __FILE__) . ' ' . $end);
+					$this->setLog($scenario, new Trad('Export de l\'historique du', __FILE__) . ' ' . $start . ' ' . new Trad('au', __FILE__) . ' ' . $end);
 
 					$histories = array();
 					$cmdExportArray = explode('&&', $this->getOptions('cmd_export'));
@@ -1813,7 +1813,7 @@ class scenarioExpression {
 						if (!is_object($cmd)) {
 							throw new Exception($GLOBALS['JEEDOM_SCLOG_TEXT']['unfoundCmdCheckId']['txt'] . $this->getOptions('cmd'));
 						}
-						$this->setLog($scenario, __('Envoi de l\'export d\'historique sur', __FILE__) . ' ' . $cmd->getHumanName());
+						$this->setLog($scenario, new Trad('Envoi de l\'export d\'historique sur', __FILE__) . ' ' . $cmd->getHumanName());
 						$cmd->execCmd($cmd_parameters);
 					}
 					if (file_exists($tmp_file)) {
@@ -1821,89 +1821,89 @@ class scenarioExpression {
 					}
 				} elseif ($this->getExpression() == 'report') {
 					$cmd_parameters = array('files' => null);
-					$this->setLog($scenario, __('Génération d\'un rapport de type', __FILE__) . ' ' . $options['type']);
+					$this->setLog($scenario, new Trad('Génération d\'un rapport de type', __FILE__) . ' ' . $options['type']);
 					switch ($options['type']) {
 						case 'view':
 							$view = view::byId($options['view_id']);
 							if (!is_object($view)) {
-								throw new Exception(__('Vue introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['view_id']);
+								throw new Exception(new Trad('Vue introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['view_id']);
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $view->getName());
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $view->getName());
 							$cmd_parameters['files'] = array($view->report($options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport', __FILE__) . ' ' . $view->getName() . ' ' . __('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $view->getName() . ' ' . __('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport', __FILE__) . ' ' . $view->getName() . ' ' . new Trad('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $view->getName() . ' ' . new Trad('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'plan':
 							$plan = planHeader::byId($options['plan_id']);
 							if (!is_object($plan)) {
-								throw new Exception(__('Design introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['plan_id']);
+								throw new Exception(new Trad('Design introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['plan_id']);
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $plan->getName());
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $plan->getName());
 							$cmd_parameters['files'] = array($plan->report($options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport', __FILE__) . ' ' . $plan->getName() . ' ' . __('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $plan->getName() . ' ' . __('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport', __FILE__) . ' ' . $plan->getName() . ' ' . new Trad('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $plan->getName() . ' ' . new Trad('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'plugin':
 							$plugin = plugin::byId($options['plugin_id']);
 							if (!is_object($plugin)) {
-								throw new Exception(__('Panel introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['plugin_id']);
+								throw new Exception(new Trad('Panel introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['plugin_id']);
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $plugin->getName());
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $plugin->getName());
 							$cmd_parameters['files'] = array($plugin->report($options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport', __FILE__) . ' ' . $plugin->getName() . ' ' . __('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $plugin->getName() . ' ' . __('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport', __FILE__) . ' ' . $plugin->getName() . ' ' . new Trad('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $plugin->getName() . ' ' . new Trad('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'eqAnalyse':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
 							if (isset($options['theme']) && $options['theme'] != '') {
 								$url .= '&theme=' . $options['theme'];
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport équipement généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport équipement généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'eqAnalyseAlert':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
 							if (isset($options['theme']) && $options['theme'] != '') {
 								$url .= '&theme=' . $options['theme'];
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $url);
 							$options['tab'] = 'alertEqlogic';
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport équipement en alert généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport équipement en alert généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'health':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=health&report=1';
 							if (isset($options['theme']) && $options['theme'] != '') {
 								$url .= '&theme=' . $options['theme'];
 							}
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'health', $options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport de santé généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport équipement du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport de santé généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'timeline':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=timeline&report=1&timeline=' . $options['timeline'];
 							if (isset($options['theme']) && $options['theme'] != '') {
 								$url .= '&theme=' . $options['theme'];
 							}
-							$this->setLog($scenario, __('Génération du rapport timeline', __FILE__) . ' ' . $options['timeline']);
+							$this->setLog($scenario, new Trad('Génération du rapport timeline', __FILE__) . ' ' . $options['timeline']);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'timeline', $options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport', __FILE__) . ' ' . $options['timeline'] . ' ' . __('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $options['timeline'] . ' ' . __('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport', __FILE__) . ' ' . $options['timeline'] . ' ' . new Trad('du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $options['timeline'] . ' ' . new Trad('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'url':
 							$url = $options['url'];
-							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
+							$this->setLog($scenario, new Trad('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'url', $options['export_type'], $options));
-							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . __('Rapport url du', __FILE__) . ' ' . date('Y-m-d H:i:s');
-							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport url généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['title'] = '[' . config::byKey('name') . ']' . ' ' . new Trad('Rapport url du', __FILE__) . ' ' . date('Y-m-d H:i:s');
+							$cmd_parameters['message'] = new Trad('Veuillez trouver ci-joint le rapport url généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 					}
 					if ($cmd_parameters['files'] === null) {
-						throw new Exception(__('Erreur : Aucun rapport généré', __FILE__));
+						throw new Exception(new Trad('Erreur : Aucun rapport généré', __FILE__));
 					}
 					if ($this->getOptions('cmd') != '') {
 						$cmdArray = explode('&&', $this->getOptions('cmd'));
@@ -1912,7 +1912,7 @@ class scenarioExpression {
 							if (!is_object($cmd)) {
 								throw new Exception($GLOBALS['JEEDOM_SCLOG_TEXT']['unfoundCmdCheckId']['txt'] . $this->getOptions('cmd'));
 							}
-							$this->setLog($scenario, __('Envoi du rapport généré sur', __FILE__) . ' ' . $cmd->getHumanName());
+							$this->setLog($scenario, new Trad('Envoi du rapport généré sur', __FILE__) . ' ' . $cmd->getHumanName());
 							$cmd->execCmd($cmd_parameters);
 						}
 					}
@@ -1930,7 +1930,7 @@ class scenarioExpression {
 						$result = $options['value'];
 					}
 					$tags['#' . $options['name'] . '#'] = $result;
-					$this->setLog($scenario, __('Mise à jour du tag', __FILE__) . ' ' . '#' . $options['name'] . '#' . ' => ' . $result);
+					$this->setLog($scenario, new Trad('Mise à jour du tag', __FILE__) . ' ' . '#' . $options['name'] . '#' . ' => ' . $result);
 					$scenario->setTags($tags);
 				} else {
 					//check user function:
@@ -1958,7 +1958,7 @@ class scenarioExpression {
 							$options['slider'] = evaluate($options['slider']);
 						}
 						if (is_array($options) && (count($options) > 1 || (isset($options['background']) && $options['background'] == 1))) {
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $cmd->getHumanName() . __(" avec comme option(s) : ", __FILE__) . json_encode($options));
+							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $cmd->getHumanName() . new Trad(" avec comme option(s) : ", __FILE__) . json_encode($options));
 						} else {
 							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['execCmd']['txt'] . $cmd->getHumanName());
 						}
@@ -1970,13 +1970,13 @@ class scenarioExpression {
 			} elseif ($this->getType() == 'condition') {
 				$expr = $this->getExpression();
 				$expression = self::setTags($expr, $scenario, true);
-				$message = __('Evaluation de la condition', __FILE__) . ' : [' . $expression . '] = ';
+				$message = new Trad('Evaluation de la condition', __FILE__) . ' : [' . $expression . '] = ';
 				$result = evaluate($expression);
 				if (is_bool($result)) {
 					if ($result) {
-						$message .= __('Vrai', __FILE__);
+						$message .= new Trad('Vrai', __FILE__);
 					} else {
-						$message .= __('Faux', __FILE__);
+						$message .= new Trad('Faux', __FILE__);
 					}
 				} else {
 					$message .= $result;

--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -494,7 +494,7 @@ class system {
 							}
 						}
 					} else {
-						$version = __('Erreur', __FILE__);
+						$version = new Trad('Erreur', __FILE__);
 					}
 					$return[$type . '::' . $package] = array(
 						'name' => $package,
@@ -507,7 +507,7 @@ class system {
 						'optional' => isset($info['optional']) ? $info['optional'] : false,
 						'reinstall' => isset($info['reinstall']) ? $info['reinstall'] : false,
 						'fix' => ($found == 0) ?  self::installPackage($type, $package) : '',
-						'remark' => isset($info['remark']) ? __($info['remark'], 'install/packages.json') : '',
+						'remark' => isset($info['remark']) ? new Trad($info['remark'], 'install/packages.json') : '',
 					);
 					continue;
 				}
@@ -523,7 +523,7 @@ class system {
 							$found = 1;
 						}
 					} else {
-						$version = __('Erreur', __FILE__);
+						$version = new Trad('Erreur', __FILE__);
 					}
 					$return[$type . '::' . $package] = array(
 						'name' => $package,
@@ -536,7 +536,7 @@ class system {
 						'optional' => isset($info['optional']) ? $info['optional'] : false,
 						'reinstall' => isset($info['reinstall']) ? $info['reinstall'] : false,
 						'fix' => ($found == 0) ?  self::installPackage($type, $package) : '',
-						'remark' => isset($info['remark']) ? __($info['remark'], 'install/composer.json') : '',
+						'remark' => isset($info['remark']) ? new Trad($info['remark'], 'install/composer.json') : '',
 					);
 					continue;
 				}
@@ -591,7 +591,7 @@ class system {
 					'optional' => isset($info['optional']) ? $info['optional'] : false,
 					'reinstall' => isset($info['reinstall']) ? $info['reinstall'] : false,
 					'fix' => ($found == 0) ? self::installPackage($type, $package, isset($info['version']) ? $info['version'] : '', $_plugin) : '',
-					'remark' => isset($info['remark']) ? __($info['remark'], 'install/packages.json') : '',
+					'remark' => isset($info['remark']) ? new Trad($info['remark'], 'install/packages.json') : '',
 				);
 			}
 		}
@@ -801,7 +801,7 @@ class system {
 
 	public static function launchScriptPackage($_plugin = '', $_force = false) {
 		if (!$_force && self::installPackageInProgress($_plugin)) {
-			throw new \Exception(__('Installation de package impossible car il y a déjà une installation en cours', __FILE__));
+			throw new \Exception(new Trad('Installation de package impossible car il y a déjà une installation en cours', __FILE__));
 		}
 		shell_exec(system::getCmdSudo() . ' chmod +x /tmp/jeedom_fix_package');
 		if (class_exists('log')) {

--- a/core/class/timeline.class.php
+++ b/core/class/timeline.class.php
@@ -224,7 +224,7 @@ class timeline {
       $name = str_replace('<span class="label"', '<span class="label-sm"',  $name);
       if ($cmd->getType() == 'action') {
         $return['html'] = '<div class="tml-cmd" data-id="' . $this->getLink_id() . '">';
-        $return['html'] .= '<span>' . $name . ' <i class="fas fa-cogs pull-right cursor bt_configureCmd" title="'.__('Configuration de la commande',__FILE__).'"></i></span>';
+        $return['html'] .= '<span>' . $name . ' <i class="fas fa-cogs pull-right cursor bt_configureCmd" title="'.new Trad('Configuration de la commande', __FILE__).'"></i></span>';
 
         $return['html'] .= '<i class="icon-blank pull-right"></i>';
         if ($return['folder'] != 'main') $return['html'] .= ' <span class="tml-folder pull-right">' . $return['folder'] . '</span>';
@@ -235,8 +235,8 @@ class timeline {
           $class = ($this->getOptions('value') == 0 ? 'success' : 'warning');
         }
         $return['html'] = '<div class="tml-cmd" data-id="' .$this->getLink_id() . '">';
-        $return['html'] .= ' <i class="fas fa-cogs pull-right cursor bt_configureCmd" title="'.__('Configuration de la commande',__FILE__).'"></i>';
-        $return['html'] .= '<span>' . $name . '<i class="fas fa-chart-line pull-right cursor bt_historicCmd" title="'.__('Historique',__FILE__).'"></i>';
+        $return['html'] .= ' <i class="fas fa-cogs pull-right cursor bt_configureCmd" title="'.new Trad('Configuration de la commande', __FILE__).'"></i>';
+        $return['html'] .= '<span>' . $name . '<i class="fas fa-chart-line pull-right cursor bt_historicCmd" title="'.new Trad('Historique', __FILE__).'"></i>';
         $return['html'] .= ' <span class="label-sm label-'.$class.'">' .$this->getOptions('value') . '</span>';
         if ($return['folder'] != 'main') $return['html'] .= ' <span class="tml-folder pull-right">' . $return['folder'] . '</span>';
         $return['html'] .= '</span>';
@@ -254,9 +254,9 @@ class timeline {
       $name = str_replace('<span class="label"', '<span class="label-sm"',  $name);
       $return['html'] = '<div class="tml-scenario" data-id="' . $this->getLink_id() . '">';
       $return['html'] .= '<div>' . $name;
-      $return['html'] .= ' <span class="label-sm label-info" title="'.__('Scénario déclenché par',__FILE__).'">' . $this->getOptions('trigger'). '</span>';
-      $return['html'] .= ' <i class="fas fa-share pull-right cursor bt_gotoScenario" title="'.__('Aller au scénario',__FILE__).'"></i> ';
-      $return['html'] .= ' <i class="fas fa-file-alt pull-right cursor bt_scenarioLog" title="'.__('Log du scénario',__FILE__).'"></i> ';
+      $return['html'] .= ' <span class="label-sm label-info" title="'.new Trad('Scénario déclenché par', __FILE__).'">' . $this->getOptions('trigger'). '</span>';
+      $return['html'] .= ' <i class="fas fa-share pull-right cursor bt_gotoScenario" title="'.new Trad('Aller au scénario', __FILE__).'"></i> ';
+      $return['html'] .= ' <i class="fas fa-file-alt pull-right cursor bt_scenarioLog" title="'.new Trad('Log du scénario', __FILE__).'"></i> ';
       if ($return['folder'] != 'main') $return['html'] .= ' <span class="tml-folder pull-right">' . $return['folder'] . '</span>';
       $return['html'] .= '</div>';
       $return['html'] .= '</div>';

--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -48,7 +48,12 @@ class translate {
 
 	public static function getConfig($_key, $_default = '') {
 		if (self::$config === null) {
-			self::$config = config::byKeys(array('language'));
+			try {
+				self::$config = config::byKeys(array('language'));
+			} catch (Exception $e) {
+				log::add('jeedom', 'warning', $e->getMessage());
+				self::$config = array();
+			}
 		}
 		if (isset(self::$config[$_key])) {
 			return self::$config[$_key];
@@ -214,8 +219,4 @@ class translate {
 	}
 
 	/*     * *********************Methode d'instance************************* */
-}
-
-function __($_content, $_name, $_backslash = false) {
-	return translate::sentence(str_replace("\'", "'", $_content), $_name, $_backslash);
 }

--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -17,7 +17,7 @@
 */
 
 /* * ***************************Includes********************************* */
-require_once __DIR__ . '/../php/core.inc.php';
+// require_once __DIR__ . '/../php/core.inc.php';
 
 /*
 //DEBUG ONLY
@@ -51,7 +51,7 @@ class translate {
 			try {
 				self::$config = config::byKeys(array('language'));
 			} catch (Exception $e) {
-				log::add('jeedom', 'warning', $e->getMessage());
+				// log::add('jeedom', 'warning', $e->getMessage());
 				self::$config = array();
 			}
 		}

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -360,6 +360,9 @@ class update {
 						if (file_exists($cibDir)) {
 							rrmdir($cibDir);
 						}
+						// re generate composer autoloader
+						$result = shell_exec(system::getCmdSudo() . ' composer dump-autoload --optimize --working-dir $WEBSERVER_HOME');
+						log::add(__CLASS__, 'debug', "Composer autoloader dump result:\n$result");
 					} else {
 						throw new Exception(__("Impossible de décompresser l'archive zip", __FILE__) . ' : ' . $tmp . ' => ' . ZipErrorMessage($res));
 					}

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -284,13 +284,13 @@ class update {
 
 	public function doUpdate() {
 		if ($this->getConfiguration('doNotUpdate') == 1  && $this->getType() != 'core') {
-			log::add(__CLASS__, 'alert', __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur', __FILE__) . ' ' . $this->getLogicalId());
+			log::add(__CLASS__, 'alert', new Trad('Vérification des mises à jour, mise à jour et réinstallation désactivées sur', __FILE__) . ' ' . $this->getLogicalId());
 			return;
 		}
 		if ($this->getType() == 'core') {
 			jeedom::update();
 		} else {
-			log::add(__CLASS__, 'alert', __('Début de la mise à jour de :', __FILE__) . ' ' . $this->getLogicalId() . "\n");
+			log::add(__CLASS__, 'alert', new Trad('Début de la mise à jour de :', __FILE__) . ' ' . $this->getLogicalId() . "\n");
 			$class = 'repo_' . $this->getSource();
 			if (class_exists($class) && method_exists($class, 'downloadObject') && config::byKey($this->getSource() . '::enable') == 1) {
 				$cibDir = jeedom::getTmpFolder('market') . '/' . $this->getLogicalId();
@@ -299,28 +299,28 @@ class update {
 				}
 				mkdir($cibDir);
 				if (!file_exists($cibDir) && !mkdir($cibDir, 0775, true)) {
-					throw new Exception(__('Impossible de créer le dossier', __FILE__) . ' : ' . $cibDir . '. ' . __('Problème de droits ?', __FILE__));
+					throw new Exception(new Trad('Impossible de créer le dossier', __FILE__) . ' : ' . $cibDir . '. ' . new Trad('Problème de droits ?', __FILE__));
 				}
-				log::add(__CLASS__, 'alert', __('Téléchargement du plugin (source', __FILE__) . ' : ' . $this->getSource() . ')...');
+				log::add(__CLASS__, 'alert', new Trad('Téléchargement du plugin (source', __FILE__) . ' : ' . $this->getSource() . ')...');
 				$info = $class::downloadObject($this);
 				if ($info['path'] !== false) {
 					$tmp = $info['path'];
-					log::add(__CLASS__, 'alert', __("OK\n", __FILE__));
+					log::add(__CLASS__, 'alert', new Trad("OK\n", __FILE__));
 
 					if (filesize($tmp) < 100) {
-						throw new Exception(__("Echec lors du téléchargement du plugin (taille inférieure à 100 octets), veuillez réessayer plus tard. Cela peut être dû à une absence de connexion au market (effectuez un test de connexion depuis la configuration générale), lié à un manque d'espace disque, une version minimale requise ou un souci sur le plugin ou son achat, etc...", __FILE__));
+						throw new Exception(new Trad("Echec lors du téléchargement du plugin (taille inférieure à 100 octets), veuillez réessayer plus tard. Cela peut être dû à une absence de connexion au market (effectuez un test de connexion depuis la configuration générale), lié à un manque d'espace disque, une version minimale requise ou un souci sur le plugin ou son achat, etc...", __FILE__));
 					}
 					$extension = strtolower(strrchr($tmp, '.'));
 					if (!in_array($extension, array('.zip'))) {
-						throw new Exception(__('Extension du fichier non valide (autorisé .zip) :', __FILE__) . ' ' . $extension);
+						throw new Exception(new Trad('Extension du fichier non valide (autorisé .zip) :', __FILE__) . ' ' . $extension);
 					}
-					log::add(__CLASS__, 'alert', __('Décompression du zip...', __FILE__));
+					log::add(__CLASS__, 'alert', new Trad('Décompression du zip...', __FILE__));
 					$zip = new ZipArchive;
 					$res = $zip->open($tmp);
 					if ($res === TRUE) {
 						if (!$zip->extractTo($cibDir . '/')) {
 							$content = file_get_contents($tmp);
-							throw new Exception(__("Impossible d'installer le plugin. Les fichiers n'ont pas pu être décompressés", __FILE__) . ' : ' . substr($content, 255));
+							throw new Exception(new Trad("Impossible d'installer le plugin. Les fichiers n'ont pas pu être décompressés", __FILE__) . ' : ' . substr($content, 255));
 						}
 						$zip->close();
 						unlink($tmp);
@@ -333,16 +333,16 @@ class update {
 						if (is_file($cibDir . '/plugin_info/info.json') && is_array($data = json_decode(file_get_contents($cibDir . '/plugin_info/info.json'), true)) && isset($data['require'])) {
 							$vJeedom = jeedom::version();
 							if (version_compare($data['require'], $vJeedom, '>')) {
-								log::add(__CLASS__, 'alert', 'KO ' . __("Version minimale requise", __FILE__) . ' (' . $data['require'] . ') > ' . __("Version Jeedom", __FILE__) . ' (' . $vJeedom . ')');
+								log::add(__CLASS__, 'alert', 'KO ' . new Trad("Version minimale requise", __FILE__) . ' (' . $data['require'] . ') > ' . new Trad("Version Jeedom", __FILE__) . ' (' . $vJeedom . ')');
 								rrmdir($cibDir);
 								$cibDir = jeedom::getTmpFolder('market') . '/' . $this->getLogicalId();
 								if (file_exists($cibDir)) {
 									rrmdir($cibDir);
 								}
-								throw new Exception($this->getLogicalId() . ' : ' . __('Version du core Jeedom non supportée, installation annulée', __FILE__));
+								throw new Exception($this->getLogicalId() . ' : ' . new Trad('Version du core Jeedom non supportée, installation annulée', __FILE__));
 							}
 						}
-						log::add(__CLASS__, 'alert', __("OK\n", __FILE__));
+						log::add(__CLASS__, 'alert', new Trad("OK\n", __FILE__));
 						$this->preInstallUpdate();
 						try {
 							if (file_exists(__DIR__ . '/../../plugins/' . $this->getLogicalId() . '/doc')) {
@@ -364,7 +364,7 @@ class update {
 						$result = shell_exec(system::getCmdSudo() . ' composer dump-autoload --optimize --working-dir $WEBSERVER_HOME');
 						log::add(__CLASS__, 'debug', "Composer autoloader dump result:\n$result");
 					} else {
-						throw new Exception(__("Impossible de décompresser l'archive zip", __FILE__) . ' : ' . $tmp . ' => ' . ZipErrorMessage($res));
+						throw new Exception(new Trad("Impossible de décompresser l'archive zip", __FILE__) . ' : ' . $tmp . ' => ' . ZipErrorMessage($res));
 					}
 				}
 				$this->postInstallUpdate($info);
@@ -376,7 +376,7 @@ class update {
 
 	public function deleteObjet() {
 		if ($this->getType() == 'core') {
-			throw new Exception(__('Vous ne pouvez pas supprimer le core de Jeedom', __FILE__));
+			throw new Exception(new Trad('Vous ne pouvez pas supprimer le core de Jeedom', __FILE__));
 		} else {
 			switch ($this->getType()) {
 				case 'plugin':
@@ -431,14 +431,14 @@ class update {
 		switch ($this->getType()) {
 			case 'plugin':
 				if (!file_exists($cibDir) && !mkdir($cibDir, 0775, true)) {
-					throw new Exception(__('Impossible de créer le dossier  :', __FILE__) . ' ' . $cibDir . __('Problème de droits ?', __FILE__));
+					throw new Exception(new Trad('Impossible de créer le dossier  :', __FILE__) . ' ' . $cibDir . new Trad('Problème de droits ?', __FILE__));
 				}
 				try {
 					$plugin = plugin::byId($this->getLogicalId());
 					if (is_object($plugin)) {
-						log::add(__CLASS__, 'alert', __('Action de pré-update...', __FILE__));
+						log::add(__CLASS__, 'alert', new Trad('Action de pré-update...', __FILE__));
 						$plugin->callInstallFunction('pre_update');
-						log::add(__CLASS__, 'alert', __("OK\n", __FILE__));
+						log::add(__CLASS__, 'alert', new Trad("OK\n", __FILE__));
 					}
 				} catch (Exception $e) {
 				} catch (Error $e) {
@@ -447,7 +447,7 @@ class update {
 	}
 
 	public function postInstallUpdate($_infos) {
-		log::add(__CLASS__, 'alert', __('Post-installation de', __FILE__) . ' ' . $this->getLogicalId() . '...');
+		log::add(__CLASS__, 'alert', new Trad('Post-installation de', __FILE__) . ' ' . $this->getLogicalId() . '...');
 		try {
 			if (function_exists('opcache_reset')) {
 				opcache_reset();
@@ -459,13 +459,13 @@ class update {
 				try {
 					$plugin = plugin::byId($this->getLogicalId());
 					$cibDir = __DIR__ . '/../../plugins/' . $this->getLogicalId();
-					log::add(__CLASS__, 'alert',  __('Vérification des droits sur les fichiers...', __FILE__));
+					log::add(__CLASS__, 'alert',  new Trad('Vérification des droits sur les fichiers...', __FILE__));
 					$cmd = system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . $cibDir . ';';
 					$cmd .= system::getCmdSudo() . 'chmod 775 -R ' . $cibDir . ';';
 					$cmd .= system::getCmdSudo() . 'chmod 775 -R ' . $cibDir . '/.*;';
 					exec($cmd);
-					log::add(__CLASS__, 'alert', __("OK", __FILE__) . "\n");
-					log::add(__CLASS__, 'alert',  __('Suppression des fichiers inutiles...', __FILE__));
+					log::add(__CLASS__, 'alert', new Trad("OK", __FILE__) . "\n");
+					log::add(__CLASS__, 'alert',  new Trad('Suppression des fichiers inutiles...', __FILE__));
 					foreach (array('3rdparty', '3rparty', 'desktop', 'mobile', 'core', 'docs', 'install', 'script', 'plugin_info') as $folder) {
 						if (!file_exists($cibDir . '/' . $folder)) {
 							continue;
@@ -474,10 +474,10 @@ class update {
 					}
 				} catch (Exception $e) {
 					$this->remove();
-					throw new Exception(__("Impossible d'installer le plugin. Le nom du plugin est différent de l'ID ou le plugin n'est pas correctement formé. Veuillez contacter l'auteur", __FILE__));
+					throw new Exception(new Trad("Impossible d'installer le plugin. Le nom du plugin est différent de l'ID ou le plugin n'est pas correctement formé. Veuillez contacter l'auteur", __FILE__));
 				} catch (Error $e) {
 					$this->remove();
-					throw new Exception(__("Impossible d'installer le plugin. Le nom du plugin est différent de l'ID ou le plugin n'est pas correctement formé. Veuillez contacter l'auteur", __FILE__));
+					throw new Exception(new Trad("Impossible d'installer le plugin. Le nom du plugin est différent de l'ID ou le plugin n'est pas correctement formé. Veuillez contacter l'auteur", __FILE__));
 				}
 				$plugin->callInstallFunction('post_plugin_install');
 				if (is_object($plugin) && $plugin->isActive()) {
@@ -491,8 +491,8 @@ class update {
 		}
 		$this->setUpdateDate(date('Y-m-d H:i:s'));
 		$this->save();
-		log::add(__CLASS__, 'alert', __("OK", __FILE__) . "\n");
-		log::add(__CLASS__, 'alert', __("END UPDATE SUCCESS", __FILE__) . "\n");
+		log::add(__CLASS__, 'alert', new Trad("OK", __FILE__) . "\n");
+		log::add(__CLASS__, 'alert', new Trad("END UPDATE SUCCESS", __FILE__) . "\n");
 	}
 
 	public static function getLastAvailableVersion() {
@@ -501,16 +501,16 @@ class update {
 			$request_http = new com_http($url);
 			return trim($request_http->exec(30));
 		} catch (Exception $e) {
-			log::add(__CLASS__, 'error', __('Erreur lors de la récuperation de la derniere version de Jeedom, url :', __FILE__) . ' ' . $url . ' => ' . log::exception($e));
+			log::add(__CLASS__, 'error', new Trad('Erreur lors de la récuperation de la derniere version de Jeedom, url :', __FILE__) . ' ' . $url . ' => ' . log::exception($e));
 		} catch (Error $e) {
-			log::add(__CLASS__, 'error', __('Erreur lors de la récuperation de la derniere version de Jeedom, url :', __FILE__) . ' ' . $url . ' => ' . log::exception($e));
+			log::add(__CLASS__, 'error', new Trad('Erreur lors de la récuperation de la derniere version de Jeedom, url :', __FILE__) . ' ' . $url . ' => ' . log::exception($e));
 		}
 		return null;
 	}
 
 	public function checkUpdate() {
 		if ($this->getConfiguration('doNotUpdate') == 1 && $this->getType() != 'core') {
-			log::add(__CLASS__, 'alert', __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur', __FILE__) . ' ' . $this->getLogicalId());
+			log::add(__CLASS__, 'alert', new Trad('Vérification des mises à jour, mise à jour et réinstallation désactivées sur', __FILE__) . ' ' . $this->getLogicalId());
 			return;
 		}
 		if ($this->getType() == 'core') {
@@ -551,14 +551,14 @@ class update {
 
 	public function preSave() {
 		if ($this->getLogicalId() == '') {
-			throw new Exception(__('Le logical ID ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('Le logical ID ne peut pas être vide', __FILE__));
 		}
 		if ($this->getName() == '') {
 			$this->setName($this->getLogicalId());
 		}
 		$repo = self::listRepo();
 		if ($this->getSource() != 'default' && !isset($repo[$this->getSource()])) {
-			throw new Exception(__('Source de mise à jour invalide : ', __FILE__) . $this->getSource());
+			throw new Exception(new Trad('Source de mise à jour invalide : ', __FILE__) . $this->getSource());
 		}
 	}
 

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -56,51 +56,51 @@ class user {
 	public static function connect(string $_login, string $_mdp) {
 		$sMdp = (!is_sha512($_mdp)) ? sha512($_mdp) : $_mdp;
 		if (config::byKey('ldap:enable') == '1' && function_exists('ldap_connect')) {
-			log::add("connection", "info", __('LDAP Authentification', __FILE__));
+			log::add("connection", "info", new Trad('LDAP Authentification', __FILE__));
 			$ad = ldap_connect(config::byKey('ldap:host'), config::byKey('ldap:port'));
 			if (!$ad) {
-				log::add("connection", "info", __('Connection LDAP Error', __FILE__));
+				log::add("connection", "info", new Trad('Connection LDAP Error', __FILE__));
 				return false;
 			}
-			log::add("connection", "info", __('LDAP Connection OK', __FILE__));
+			log::add("connection", "info", new Trad('LDAP Connection OK', __FILE__));
 			ldap_set_option($ad, LDAP_OPT_PROTOCOL_VERSION, 3);
 			ldap_set_option($ad, LDAP_OPT_REFERRALS, 0);
 			if (config::byKey('ldap:tls')) {
 				if (!ldap_start_tls($ad)) {
-					log::add("connection", "debug", __('start TLS KO', __FILE__));
+					log::add("connection", "debug", new Trad('start TLS KO', __FILE__));
 					return false;
 				} else {
-					log::add("connection", "debug", __('start TLS OK', __FILE__));
+					log::add("connection", "debug", new Trad('start TLS OK', __FILE__));
 				}
 			}
 			if (config::byKey('ldap:samba4')) {
 				if (!ldap_bind($ad, $_login . '@' . config::byKey('ldap:domain'), $_mdp)) {
-					log::add("connection", "info", __('LDAP bind user - login/password denied', __FILE__));
+					log::add("connection", "info", new Trad('LDAP bind user - login/password denied', __FILE__));
 					return false;
 				}
 			} else {
 				if (!ldap_bind($ad, config::byKey('ldap::usersearch') . '=' . $_login . ',' . config::byKey('ldap:basedn'), $_mdp)) {
-					log::add("connection", "info", __('LDAP bind user - login/password denied', __FILE__));
+					log::add("connection", "info", new Trad('LDAP bind user - login/password denied', __FILE__));
 					return false;
 				}
 			}
-			log::add("connection", "debug", __('LDAP Bind user - OK', __FILE__));
+			log::add("connection", "debug", new Trad('LDAP Bind user - OK', __FILE__));
 			if (config::bykey('ldap:filter:admin') == "" && config::bykey('ldap:filter:user') == "" && config::bykey('ldap:filter:restrict') == "") {
-				log::add("connection", "warning", __('LDAP Profile Check - [WARNING] None filter was set, "', __FILE__) . $_login . __('"  authenticated as an administrator', __FILE__));
+				log::add("connection", "warning", new Trad('LDAP Profile Check - [WARNING] None filter was set, "', __FILE__) . $_login . new Trad('"  authenticated as an administrator', __FILE__));
 				$profile = 'admin';
 			} else {
 				foreach (array('admin', 'user', 'restrict', 'none') as $profile) {
 					if ($profile == 'none') {
-						log::add("connection", "warning", __('LDAP Profile Check - [WARNING] No profile has been set for "', __FILE__) . $_login . __('" user in the LDAP', __FILE__));
+						log::add("connection", "warning", new Trad('LDAP Profile Check - [WARNING] No profile has been set for "', __FILE__) . $_login . new Trad('" user in the LDAP', __FILE__));
 						break;
 					}
 					if (config::bykey('ldap:filter:' . $profile) != "") {
 						$filters = '(&(' . config::bykey('ldap::usersearch') . '=' . $_login . ')' . config::bykey('ldap:filter:' . $profile) . ')';
-						log::add("connection", "debug", __('LDAP Profile Check - filter:, "' . $filters . '"', __FILE__));
+						log::add("connection", "debug", new Trad('LDAP Profile Check - filter:, "' . $filters . '"', __FILE__));
 						$result = ldap_search($ad, config::byKey('ldap:basedn'), $filters);
 						$entries = ldap_get_entries($ad, $result);
 						if ($entries['count'] > 0) {
-							log::add("connection", "info", __('LDAP Profile Check - The "', __FILE__) . $profile . __('" profile was FOUND for "', __FILE__) . $_login . __('" user in the LDAP', __FILE__));
+							log::add("connection", "info", new Trad('LDAP Profile Check - The "', __FILE__) . $profile . new Trad('" profile was FOUND for "', __FILE__) . $_login . new Trad('" user in the LDAP', __FILE__));
 							break;
 						}
 					}
@@ -121,17 +121,17 @@ class user {
 					->setOptions('lastConnection', date('Y-m-d H:i:s'))
 					->setProfils($profile);
 				$user->save();
-				log::add("connection", "info", __('User created from the LDAP :', __FILE__) . ' ' . $_login);
+				log::add("connection", "info", new Trad('User created from the LDAP :', __FILE__) . ' ' . $_login);
 				jeedom::event('user_connect');
 				// TODO : if username == password => change ldap password
-				log::add('event', 'info', __('User connection accepted', __FILE__) . ' ' . $_login);
+				log::add('event', 'info', new Trad('User connection accepted', __FILE__) . ' ' . $_login);
 				return $user;
 			} else {
 				$user = self::byLogin($_login);
 				if (is_object($user)) {
 					$user->remove();
 				}
-				log::add("connection", "info", __('User not allowed to access to Jeedom according to the LDAP (', __FILE__) . $_login . ')');
+				log::add("connection", "info", new Trad('User not allowed to access to Jeedom according to the LDAP (', __FILE__) . $_login . ')');
 			}
 		}
 		$user = user::byLoginAndPassword($_login, $sMdp);
@@ -139,15 +139,15 @@ class user {
 			$user = user::byLoginAndPassword($_login, sha1($_mdp));
 			if (is_object($user)) {
 				$user->setPassword($sMdp);
-				log::add('event', 'info', __('Local account found for', __FILE__) . ' ' . $_login);
+				log::add('event', 'info', new Trad('Local account found for', __FILE__) . ' ' . $_login);
 			}
 		}
 		if (is_object($user)) {
 			$user->setOptions('lastConnection', date('Y-m-d H:i:s'));
 			$user->save();
 			jeedom::event('user_connect');
-			log::add('event', 'info', __('Local account found for', __FILE__) . ' ' . $_login);
-			log::add('event', 'info', __('User connection accepted', __FILE__) . ' ' . $_login);
+			log::add('event', 'info', new Trad('Local account found for', __FILE__) . ' ' . $_login);
+			log::add('event', 'info', new Trad('User connection accepted', __FILE__) . ' ' . $_login);
 		}
 		return $user;
 	}
@@ -397,7 +397,7 @@ class user {
 			$cmd = $user->getOptions('notification::cmd');
 			if ($cmd != '') {
 				if (!cmd::byId(str_replace('#', '', $cmd))) {
-					$return[] = array('detail' => __('Utilisateur', __FILE__), 'help' => __('Commande notification utilisateur', __FILE__), 'who' => $cmd);
+					$return[] = array('detail' => new Trad('Utilisateur', __FILE__), 'help' => new Trad('Commande notification utilisateur', __FILE__), 'who' => $cmd);
 				}
 			}
 		}
@@ -421,24 +421,24 @@ class user {
 
 	public function preInsert(): void {
 		if (is_object(self::byLogin($this->getLogin()))) {
-			throw new Exception(__('Ce nom d\'utilisateur est déja pris', __FILE__));
+			throw new Exception(new Trad('Ce nom d\'utilisateur est déja pris', __FILE__));
 		}
 	}
 
 	public function preSave(): void {
 		if ($this->getLogin() == '') {
-			throw new Exception(__('Le nom d\'utilisateur ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('Le nom d\'utilisateur ne peut pas être vide', __FILE__));
 		}
 		if ($this->getPassword() == '') {
-			throw new Exception(__('Le mot de passe ne peut etre vide', __FILE__));
+			throw new Exception(new Trad('Le mot de passe ne peut etre vide', __FILE__));
 		}
 		$admins = user::byProfils('admin', true);
 		if (count($admins) == 1 && $admins[0]->getId() == $this->getId()) {
 			if ($this->getProfils() == 'admin' && $this->getEnable() == 0) {
-				throw new Exception(__('Vous ne pouvez désactiver le dernier utilisateur', __FILE__));
+				throw new Exception(new Trad('Vous ne pouvez désactiver le dernier utilisateur', __FILE__));
 			}
 			if ($this->getProfils() != 'admin') {
-				throw new Exception(__('Vous ne pouvez changer le profil du dernier administrateur', __FILE__));
+				throw new Exception(new Trad('Vous ne pouvez changer le profil du dernier administrateur', __FILE__));
 			}
 		}
 	}
@@ -457,7 +457,7 @@ class user {
 
 	public function preRemove(): void {
 		if (count(user::byProfils('admin', true)) == 1 && ($this->getProfils() == 'admin' && $this->getEnable() == 1)) {
-			throw new Exception(__('Vous ne pouvez supprimer le dernier administrateur', __FILE__));
+			throw new Exception(new Trad('Vous ne pouvez supprimer le dernier administrateur', __FILE__));
 		}
 	}
 
@@ -513,7 +513,7 @@ class user {
 		if ($_password != '') {
 			$_password = (!is_sha512($_password)) ? sha512($_password) : $_password;
 		} else {
-			throw new Exception(__('Le mot de passe ne peut etre vide', __FILE__));
+			throw new Exception(new Trad('Le mot de passe ne peut etre vide', __FILE__));
 		}
 		$this->_changed = utils::attrChanged($this->_changed, $this->password, $_password);
 		$this->password = $_password;

--- a/core/class/view.class.php
+++ b/core/class/view.class.php
@@ -108,7 +108,7 @@ class view {
 	 */
 	public function presave() {
 		if (trim($this->getName()) == '') {
-			throw new Exception(__('Le nom de la vue ne peut pas être vide', __FILE__));
+			throw new Exception(new Trad('Le nom de la vue ne peut pas être vide', __FILE__));
 		}
 	}
 
@@ -248,7 +248,7 @@ class view {
 		$icon = findCodeIcon($this->getDisplay('icon', '<i class="far fa-image"></i>'));
 		$_data['node']['view' . $this->getId()] = array(
 			'id' => 'view' . $this->getId(),
-			'type' => __('Vue', __FILE__),
+			'type' => new Trad('Vue', __FILE__),
 			'name' => substr($this->getName(), 0, 20),
 			'icon' => $icon['icon'],
 			'fontfamily' => $icon['fontfamily'],
@@ -256,7 +256,7 @@ class view {
 			'fontweight' => ($_level == 1) ? 'bold' : 'normal',
 			'texty' => -14,
 			'textx' => 0,
-			'title' => __('Vue :', __FILE__) . ' ' . $this->getName(),
+			'title' => new Trad('Vue :', __FILE__) . ' ' . $this->getName(),
 			'url' => 'index.php?v=d&p=view&view_id=' . $this->getId(),
 		);
 	}

--- a/core/com/http.com.php
+++ b/core/com/http.com.php
@@ -136,10 +136,10 @@ class com_http {
 					return $response;
 				}
 				if ($this->getNoReportError() === false && $this->getLogError()) {
-					log::add('http.com', 'error', __('Erreur cURL :', __FILE__) . ' ' . $curl_error . ' ' . __('sur la commande', __FILE__) . ' ' . $this->url . ' ' . __('après', __FILE__) . ' ' . $nbRetry . ' ' . __('relance(s)', __FILE__));
+					log::add('http.com', 'error', new Trad('Erreur cURL :', __FILE__) . ' ' . $curl_error . ' ' . new Trad('sur la commande', __FILE__) . ' ' . $this->url . ' ' . new Trad('après', __FILE__) . ' ' . $nbRetry . ' ' . new Trad('relance(s)', __FILE__));
 				}
 				if ($this->getNoReportError() === false) {
-					throw new Exception(__('Echec de la requête HTTP :', __FILE__) . ' ' . $this->url . ' cURL error : ' . $curl_error, 404);
+					throw new Exception(new Trad('Echec de la requête HTTP :', __FILE__) . ' ' . $this->url . ' cURL error : ' . $curl_error, 404);
 				}
 			} else {
 				unset($ch);

--- a/core/com/shell.com.php
+++ b/core/com/shell.com.php
@@ -97,7 +97,7 @@ class com_shell {
 			exec($cmd, $output, $retval);
 			$return[] = implode("\n", $output);
 			if ($retval != 0) {
-				throw new Exception(__('Erreur sur ',__FILE__).$cmd.' ' . __('valeur retournée : ',__FILE__) . $retval . '. ' . __('Détails : ' ,__FILE__). implode("\n", $output));
+				throw new Exception(new Trad('Erreur sur ', __FILE__).$cmd.' ' . new Trad('valeur retournée : ', __FILE__) . $retval . '. ' . new Trad('Détails : ' , __FILE__). implode("\n", $output));
 			}
 			$this->history[] = $cmd;
 		}

--- a/core/config/jeedom.config.php
+++ b/core/config/jeedom.config.php
@@ -20,14 +20,14 @@ global $JEEDOM_INTERNAL_CONFIG;
 $JEEDOM_INTERNAL_CONFIG = array(
 	'eqLogic' => array(
 		'category' => array(
-			'heating' => array('name' => __('Chauffage', __FILE__), 'icon' => 'fas fa-fire'),
-			'security' => array('name' => __('Sécurité', __FILE__), 'icon' => 'fas fa-lock'),
-			'energy' => array('name' => __('Energie', __FILE__), 'icon' => 'fas fa-bolt'),
-			'light' => array('name' => __('Lumière', __FILE__), 'icon' => 'far fa-lightbulb'),
-			'opening' => array('name' => __('Ouvrant', __FILE__), 'icon' => 'fas fa-door-open'),
-			'automatism' => array('name' => __('Automatisme', __FILE__), 'icon' => 'fas fa-magic'),
-			'multimedia' => array('name' => __('Multimédia', __FILE__), 'icon' => 'fas fa-sliders-h'),
-			'default' => array('name' => __('Autre', __FILE__), 'icon' => 'far fa-circle'),
+			'heating' => array('name' => new Trad( 'Chauffage', __FILE__), 'icon' => 'fas fa-fire'),
+			'security' => array('name' => new Trad( 'Sécurité', __FILE__), 'icon' => 'fas fa-lock'),
+			'energy' => array('name' => new Trad( 'Energie', __FILE__), 'icon' => 'fas fa-bolt'),
+			'light' => array('name' => new Trad( 'Lumière', __FILE__), 'icon' => 'far fa-lightbulb'),
+			'opening' => array('name' => new Trad( 'Ouvrant', __FILE__), 'icon' => 'fas fa-door-open'),
+			'automatism' => array('name' => new Trad( 'Automatisme', __FILE__), 'icon' => 'fas fa-magic'),
+			'multimedia' => array('name' => new Trad( 'Multimédia', __FILE__), 'icon' => 'fas fa-sliders-h'),
+			'default' => array('name' => new Trad( 'Autre', __FILE__), 'icon' => 'far fa-circle'),
 		),
 		'displayType' => array(
 			'dashboard' => array('name' => 'Dashboard'),
@@ -44,34 +44,34 @@ $JEEDOM_INTERNAL_CONFIG = array(
 	),
 	'plugin' => array(
 		'category' => array(
-			'security' => array('name' => __('Sécurité', __FILE__), 'icon' => 'fas fa-lock'),
-			'automation protocol' => array('name' => __('Protocole domotique', __FILE__), 'icon' => 'fas fa-rss'),
-			'home automation protocol' => array('name' => __('Passerelle domotique', __FILE__), 'icon' => 'fas fa-asterisk'),
-			'programming' => array('name' => __('Programmation', __FILE__), 'icon' => 'fas fa-code'),
-			'organization' => array('name' => __('Organisation', __FILE__), 'icon' => 'far fa-calendar-alt', 'alias' => array('travel', 'finance')),
-			'weather' => array('name' => __('Météo', __FILE__), 'icon' => 'far fa-sun'),
-			'communication' => array('name' => __('Communication', __FILE__), 'icon' => 'fas fa-comment'),
-			'devicecommunication' => array('name' => __('Objets connectés', __FILE__), 'icon' => 'fas fa-language'),
-			'multimedia' => array('name' => __('Multimédia', __FILE__), 'icon' => 'fas fa-sliders-h'),
-			'wellness' => array('name' => __('Confort', __FILE__), 'icon' => 'far fa-user'),
-			'monitoring' => array('name' => __('Monitoring', __FILE__), 'icon' => 'fas fa-tachometer-alt'),
-			'health' => array('name' => __('Santé', __FILE__), 'icon' => 'icon loisir-runner5'),
-			'nature' => array('name' => __('Nature', __FILE__), 'icon' => 'icon nature-leaf32'),
-			'automatisation' => array('name' => __('Automatisme', __FILE__), 'icon' => 'fas fa-magic'),
-			'energy' => array('name' => __('Energie', __FILE__), 'icon' => 'fas fa-bolt'),
-			'other' => array('name' => __('Autre', __FILE__), 'icon' => 'fas fa-bars'),
+			'security' => array('name' => new Trad( 'Sécurité', __FILE__), 'icon' => 'fas fa-lock'),
+			'automation protocol' => array('name' => new Trad( 'Protocole domotique', __FILE__), 'icon' => 'fas fa-rss'),
+			'home automation protocol' => array('name' => new Trad( 'Passerelle domotique', __FILE__), 'icon' => 'fas fa-asterisk'),
+			'programming' => array('name' => new Trad( 'Programmation', __FILE__), 'icon' => 'fas fa-code'),
+			'organization' => array('name' => new Trad( 'Organisation', __FILE__), 'icon' => 'far fa-calendar-alt', 'alias' => array('travel', 'finance')),
+			'weather' => array('name' => new Trad( 'Météo', __FILE__), 'icon' => 'far fa-sun'),
+			'communication' => array('name' => new Trad( 'Communication', __FILE__), 'icon' => 'fas fa-comment'),
+			'devicecommunication' => array('name' => new Trad( 'Objets connectés', __FILE__), 'icon' => 'fas fa-language'),
+			'multimedia' => array('name' => new Trad( 'Multimédia', __FILE__), 'icon' => 'fas fa-sliders-h'),
+			'wellness' => array('name' => new Trad( 'Confort', __FILE__), 'icon' => 'far fa-user'),
+			'monitoring' => array('name' => new Trad( 'Monitoring', __FILE__), 'icon' => 'fas fa-tachometer-alt'),
+			'health' => array('name' => new Trad( 'Santé', __FILE__), 'icon' => 'icon loisir-runner5'),
+			'nature' => array('name' => new Trad( 'Nature', __FILE__), 'icon' => 'icon nature-leaf32'),
+			'automatisation' => array('name' => new Trad( 'Automatisme', __FILE__), 'icon' => 'fas fa-magic'),
+			'energy' => array('name' => new Trad( 'Energie', __FILE__), 'icon' => 'fas fa-bolt'),
+			'other' => array('name' => new Trad( 'Autre', __FILE__), 'icon' => 'fas fa-bars'),
 		),
 	),
 	'messageChannel' => array(
-		'alerting' => array('name' => __('Alerte des commandes', __FILE__), 'icon' => '<i class="far fa-bell"></i>'),
-		'alertingReturnBack' => array('name' => __('Retour à l\'état normal des commandes', __FILE__), 'icon' => '<i class="fas fa-check"></i>')
+		'alerting' => array('name' => new Trad( 'Alerte des commandes', __FILE__), 'icon' => '<i class="far fa-bell"></i>'),
+		'alertingReturnBack' => array('name' => new Trad( 'Retour à l\'état normal des commandes', __FILE__), 'icon' => '<i class="fas fa-check"></i>')
 	),
 	'alerts' => array(
-		'timeout' => array('name' => __('Timeout', __FILE__), 'icon' => 'far fa-clock', 'level' => 6, 'check' => false, 'color' => 'var(--al-danger-color)'),
-		'batterywarning' => array('name' => __('Batterie en Warning', __FILE__), 'icon' => 'fas fa-battery-quarter', 'level' => 2, 'check' => false, 'color' => 'var(--al-warning-color)'),
-		'batterydanger' => array('name' => __('Batterie en Danger', __FILE__), 'icon' => 'fas fa-battery-empty', 'level' => 3, 'check' => false, 'color' => 'var(--al-danger-color)'),
-		'warning' => array('name' => __('Warning', __FILE__), 'icon' => 'fas fa-bell', 'level' => 4, 'check' => true, 'color' => 'var(--al-warning-color)'),
-		'danger' => array('name' => __('Danger', __FILE__), 'icon' => 'fas fa-exclamation', 'level' => 5, 'check' => true, 'color' => 'var(--al-danger-color)'),
+		'timeout' => array('name' => new Trad( 'Timeout', __FILE__), 'icon' => 'far fa-clock', 'level' => 6, 'check' => false, 'color' => 'var(--al-danger-color)'),
+		'batterywarning' => array('name' => new Trad( 'Batterie en Warning', __FILE__), 'icon' => 'fas fa-battery-quarter', 'level' => 2, 'check' => false, 'color' => 'var(--al-warning-color)'),
+		'batterydanger' => array('name' => new Trad( 'Batterie en Danger', __FILE__), 'icon' => 'fas fa-battery-empty', 'level' => 3, 'check' => false, 'color' => 'var(--al-danger-color)'),
+		'warning' => array('name' => new Trad( 'Warning', __FILE__), 'icon' => 'fas fa-bell', 'level' => 4, 'check' => true, 'color' => 'var(--al-warning-color)'),
+		'danger' => array('name' => new Trad( 'Danger', __FILE__), 'icon' => 'fas fa-exclamation', 'level' => 5, 'check' => true, 'color' => 'var(--al-danger-color)'),
 	),
 	'cmd' => array(
 		'widgets' => array(
@@ -168,700 +168,700 @@ $JEEDOM_INTERNAL_CONFIG = array(
 		),
 		'generic_type' => array(
 			'TOGGLE' => array(
-				'name' => __('Toggle', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Toggle', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'ONLINE' => array(
-				'name' => __('Connecté', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Connecté', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'LIGHT_TOGGLE' => array(
-				'name' => __('Lumière Toggle', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Toggle', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'LIGHT_STATE' => array(
-				'name' => __('Lumière Etat', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Etat', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'LIGHT_ON' => array(
-				'name' => __('Lumière Bouton On', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Bouton On', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'LIGHT_OFF' => array(
-				'name' => __('Lumière Bouton Off', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Bouton Off', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'LIGHT_SLIDER' => array(
-				'name' => __('Lumière Slider', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Slider', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'slider'), 'subtype' => array('slider')
 			),
 			'LIGHT_BRIGHTNESS' => array(
-				'name' => __('Lumière Luminosité', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Luminosité', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'LIGHT_COLOR' => array(
-				'name' => __('Lumière Couleur', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Couleur', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'LIGHT_SET_COLOR' => array(
-				'name' => __('Lumière Couleur', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Couleur', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'color'), 'subtype' => array('color')
 			),
 			'LIGHT_MODE' => array(
-				'name' => __('Lumière Mode', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Mode', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action', 'subtype' => array('other','select')
 			),
 			'LIGHT_STATE_BOOL' => array(
-				'name' => __('Lumière Etat (Binaire)', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Etat (Binaire)', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'LIGHT_COLOR_TEMP' => array(
-				'name' => __('Lumière Température Couleur', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Température Couleur', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'LIGHT_SET_COLOR_TEMP' => array(
-				'name' => __('Lumière Température Couleur', __FILE__), 'familyid' => 'Light', 'family' => __('Lumière', __FILE__),
+				'name' => new Trad( 'Lumière Température Couleur', __FILE__), 'familyid' => 'Light', 'family' => new Trad( 'Lumière', __FILE__),
 				'type' => 'Action'
 			),
 			'ENERGY_STATE' => array(
-				'name' => __('Prise Etat', __FILE__), 'familyid' => 'Outlet', 'family' => __('Prise', __FILE__),
+				'name' => new Trad( 'Prise Etat', __FILE__), 'familyid' => 'Outlet', 'family' => new Trad( 'Prise', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric', 'binary')
 			),
 			'ENERGY_ON' => array(
-				'name' => __('Prise Bouton On', __FILE__), 'familyid' => 'Outlet', 'family' => __('Prise', __FILE__),
+				'name' => new Trad( 'Prise Bouton On', __FILE__), 'familyid' => 'Outlet', 'family' => new Trad( 'Prise', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'ENERGY_OFF' => array(
-				'name' => __('Prise Bouton Off', __FILE__), 'familyid' => 'Outlet', 'family' => __('Prise', __FILE__),
+				'name' => new Trad( 'Prise Bouton Off', __FILE__), 'familyid' => 'Outlet', 'family' => new Trad( 'Prise', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'ENERGY_SLIDER' => array(
-				'name' => __('Prise Slider', __FILE__), 'familyid' => 'Outlet', 'family' => __('Prise', __FILE__),
+				'name' => new Trad( 'Prise Slider', __FILE__), 'familyid' => 'Outlet', 'family' => new Trad( 'Prise', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'slider')
 			),
 			'FLAP_STATE' => array(
-				'name' => __('Volet Etat', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet Etat', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'FLAP_UP' => array(
-				'name' => __('Volet Bouton Monter', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet Bouton Monter', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'FLAP_DOWN' => array(
-				'name' => __('Volet Bouton Descendre', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet Bouton Descendre', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'FLAP_STOP' => array(
-				'name' => __('Volet Bouton Stop', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet Bouton Stop', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action'
 			),
 			'FLAP_SLIDER' => array(
-				'name' => __('Volet Bouton Slider', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet Bouton Slider', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'slider'), 'subtype' => array('slider')
 			),
 			'FLAP_BSO_STATE' => array(
-				'name' => __('Volet BSO Etat', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet BSO Etat', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'FLAP_BSO_UP' => array(
-				'name' => __('Volet BSO Bouton Monter', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet BSO Bouton Monter', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'FLAP_BSO_DOWN' => array(
-				'name' => __('Volet BSO Bouton Descendre', __FILE__), 'familyid' => 'Shutter', 'family' => __('Volet', __FILE__),
+				'name' => new Trad( 'Volet BSO Bouton Descendre', __FILE__), 'familyid' => 'Shutter', 'family' => new Trad( 'Volet', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'HEATING_ON' => array(
-				'name' => __('Chauffage fil pilote Bouton ON', __FILE__), 'familyid' => 'Heating', 'family' => __('Chauffage', __FILE__),
+				'name' => new Trad( 'Chauffage fil pilote Bouton ON', __FILE__), 'familyid' => 'Heating', 'family' => new Trad( 'Chauffage', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'HEATING_OFF' => array(
-				'name' => __('Chauffage fil pilote Bouton OFF', __FILE__), 'familyid' => 'Heating', 'family' => __('Chauffage', __FILE__),
+				'name' => new Trad( 'Chauffage fil pilote Bouton OFF', __FILE__), 'familyid' => 'Heating', 'family' => new Trad( 'Chauffage', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'HEATING_STATE' => array(
-				'name' => __('Chauffage fil pilote Etat', __FILE__), 'familyid' => 'Heating', 'family' => __('Chauffage', __FILE__),
+				'name' => new Trad( 'Chauffage fil pilote Etat', __FILE__), 'familyid' => 'Heating', 'family' => new Trad( 'Chauffage', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'HEATING_OTHER' => array(
-				'name' => __('Chauffage fil pilote Bouton', __FILE__), 'familyid' => 'Heating', 'family' => __('Chauffage', __FILE__),
+				'name' => new Trad( 'Chauffage fil pilote Bouton', __FILE__), 'familyid' => 'Heating', 'family' => new Trad( 'Chauffage', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'LOCK_STATE' => array(
-				'name' => __('Serrure Etat', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Serrure Etat', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'LOCK_OPEN' => array(
-				'name' => __('Serrure Bouton Ouvrir', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Serrure Bouton Ouvrir', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'LOCK_CLOSE' => array(
-				'name' => __('Serrure Bouton Fermer', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Serrure Bouton Fermer', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'GB_OPEN' => array(
-				'name' => __('Portail ou garage bouton d\'ouverture', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Portail ou garage bouton d\'ouverture', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'GB_CLOSE' => array(
-				'name' => __('Portail ou garage bouton de fermeture', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Portail ou garage bouton de fermeture', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'GB_TOGGLE' => array(
-				'name' => __('Portail ou garage bouton toggle', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Portail ou garage bouton toggle', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'BARRIER_STATE' => array(
-				'name' => __('Portail (ouvrant) Etat', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Portail (ouvrant) Etat', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'GARAGE_STATE' => array(
-				'name' => __('Garage (ouvrant) Etat', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Garage (ouvrant) Etat', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'OPENING' => array(
-				'name' => __('Porte', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Porte', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'OPENING_WINDOW' => array(
-				'name' => __('Fenêtre', __FILE__), 'familyid' => 'Opening', 'family' => __('Ouvrant', __FILE__),
+				'name' => new Trad( 'Fenêtre', __FILE__), 'familyid' => 'Opening', 'family' => new Trad( 'Ouvrant', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'THERMOSTAT_STATE' => array(
-				'name' => __('Thermostat Etat', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Etat', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'THERMOSTAT_TEMPERATURE' => array(
-				'name' => __('Thermostat Température ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Température ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'THERMOSTAT_SET_SETPOINT' => array(
-				'name' => __('Thermostat consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'THERMOSTAT_SETPOINT' => array(
-				'name' => __('Thermostat consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'THERMOSTAT_SET_MODE' => array(
-				'name' => __('Thermostat Mode', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Mode', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('other','select')
 			),
 			'THERMOSTAT_MODE' => array(
-				'name' => __('Thermostat Mode', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Mode', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'THERMOSTAT_SET_LOCK' => array(
-				'name' => __('Thermostat Verrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Verrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'THERMOSTAT_SET_UNLOCK' => array(
-				'name' => __('Thermostat Déverrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Déverrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'THERMOSTAT_LOCK' => array(
-				'name' => __('Thermostat Verrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Verrouillage', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'THERMOSTAT_TEMPERATURE_OUTDOOR' => array(
-				'name' => __('Thermostat Température Exterieur', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Température Exterieur', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'THERMOSTAT_STATE_NAME' => array(
-				'name' => __('Thermostat Etat (HUMAIN)', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat Etat (HUMAIN)', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'THERMOSTAT_HUMIDITY' => array(
-				'name' => __('Thermostat humidité ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat humidité ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'THERMOSTAT_SET_MAX_TEMP' => array(
-				'name' => __('Thermostat maximum consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat maximum consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'THERMOSTAT_SET_MIN_TEMP' => array(
-				'name' => __('Thermostat minimum consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat minimum consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'THERMOSTAT_HUMIDITY' => array(
-				'name' => __('Thermostat humidité ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Thermostat humidité ambiante', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'HUMIDITY_SETPOINT' => array(
-				'name' => __('Humidité consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Humidité consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Info', 'subtype' => array('slider')
 			),
 			'HUMIDITY_SET_SETPOINT' => array(
-				'name' => __('Humidité consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => __('Thermostat', __FILE__),
+				'name' => new Trad( 'Humidité consigne', __FILE__), 'familyid' => 'Thermostat', 'family' => new Trad( 'Thermostat', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'CAMERA_UP' => array(
-				'name' => __('Mouvement caméra vers le haut', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Mouvement caméra vers le haut', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_DOWN' => array(
-				'name' => __('Mouvement caméra vers le bas', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Mouvement caméra vers le bas', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_LEFT' => array(
-				'name' => __('Mouvement caméra vers la gauche', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Mouvement caméra vers la gauche', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_RIGHT' => array(
-				'name' => __('Mouvement caméra vers la droite', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Mouvement caméra vers la droite', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_ZOOM' => array(
-				'name' => __('Zoom caméra vers l\'avant', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Zoom caméra vers l\'avant', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_DEZOOM' => array(
-				'name' => __('Zoom caméra vers l\'arrière', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Zoom caméra vers l\'arrière', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_STOP' => array(
-				'name' => __('Stop caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Stop caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_PRESET' => array(
-				'name' => __('Preset caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Preset caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'CAMERA_URL' => array(
-				'name' => __('URL caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'URL caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'CAMERA_RECORD_STATE' => array(
-				'name' => __('État enregistrement caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'État enregistrement caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'CAMERA_RECORD' => array(
-				'name' => __('Enregistrement caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Enregistrement caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action'
 			),
 			'CAMERA_TAKE' => array(
-				'name' => __('Snapshot caméra', __FILE__), 'familyid' => 'Camera', 'family' => __('Caméra', __FILE__),
+				'name' => new Trad( 'Snapshot caméra', __FILE__), 'familyid' => 'Camera', 'family' => new Trad( 'Caméra', __FILE__),
 				'type' => 'Action'
 			),
 			'MODE_STATE' => array(
-				'name' => __('Mode Etat', __FILE__), 'familyid' => 'Mode', 'family' => __('Mode', __FILE__),
+				'name' => new Trad( 'Mode Etat', __FILE__), 'familyid' => 'Mode', 'family' => new Trad( 'Mode', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'MODE_SET_STATE' => array(
-				'name' => __('Changer Mode', __FILE__), 'familyid' => 'Mode', 'family' => __('Mode', __FILE__),
+				'name' => new Trad( 'Changer Mode', __FILE__), 'familyid' => 'Mode', 'family' => new Trad( 'Mode', __FILE__),
 				'type' => 'Action', 'subtype' => array('other','select')
 			),
 			'SIREN_STATE' => array(
-				'name' => __('Sirène Etat', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Sirène Etat', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'SIREN_OFF' => array(
-				'name' => __('Sirène Bouton Off', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Sirène Bouton Off', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'SIREN_ON' => array(
-				'name' => __('Sirène Bouton On', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Sirène Bouton On', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Action', 'summary' => array('subtype' => 'other'), 'subtype' => array('other')
 			),
 			'ALARM_STATE' => array(
-				'name' => __('Alarme Etat', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme Etat', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'string')
 			),
 			'ALARM_MODE' => array(
-				'name' => __('Alarme mode', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme mode', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'ALARM_ENABLE_STATE' => array(
-				'name' => __('Alarme Etat activée', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme Etat activée', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'ALARM_ARMED' => array(
-				'name' => __('Alarme armée', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme armée', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'ALARM_RELEASED' => array(
-				'name' => __('Alarme libérée', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme libérée', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'ALARM_SET_MODE' => array(
-				'name' => __('Alarme Mode', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Alarme Mode', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Action', 'subtype' => array('other','select')
 			),
 			'FLOOD' => array(
-				'name' => __('Inondation', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Inondation', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'SABOTAGE' => array(
-				'name' => __('Sabotage', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Sabotage', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'SHOCK' => array(
-				'name' => __('Choc', __FILE__), 'familyid' => 'Security', 'family' => __('Sécurité', __FILE__),
+				'name' => new Trad( 'Choc', __FILE__), 'familyid' => 'Security', 'family' => new Trad( 'Sécurité', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'WEATHER_TEMPERATURE' => array(
-				'name' => __('Météo Température', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_HUMIDITY' => array(
-				'name' => __('Météo Humidité', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Humidité', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_PRESSURE' => array(
-				'name' => __('Météo Pression', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Pression', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_WIND_SPEED' => array(
-				'name' => __('Météo vitesse du vent', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo vitesse du vent', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_WIND_DIRECTION' => array(
-				'name' => __('Météo direction du vent', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo direction du vent', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_SUNSET' => array(
-				'name' => __('Météo coucher de soleil', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo coucher de soleil', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_SUNRISE' => array(
-				'name' => __('Météo lever de soleil', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo lever de soleil', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MIN' => array(
-				'name' => __('Météo Température min', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température min', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MAX' => array(
-				'name' => __('Météo Température max', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température max', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_CONDITION' => array(
-				'name' => __('Météo condition', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'WEATHER_CONDITION_ID' => array(
-				'name' => __('Météo condition (id)', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition (id)', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'text'
 			),
 			'WEATHER_TEMPERATURE_MIN_1' => array(
-				'name' => __('Météo Température min j+1', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température min j+1', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MAX_1' => array(
-				'name' => __('Météo Température max j+1', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température max j+1', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_CONDITION_1' => array(
-				'name' => __('Météo condition j+1', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition j+1', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('string'), 'calcul' => 'text'
 			),
 			'WEATHER_CONDITION_ID_1' => array(
-				'name' => __('Météo condition (id) j+1', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition (id) j+1', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'text'
 			),
 			'WEATHER_TEMPERATURE_MIN_2' => array(
-				'name' => __('Météo Température min j+2', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température min j+2', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MAX_2' => array(
-				'name' => __('Météo condition j+1 max j+2', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition j+1 max j+2', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_CONDITION_2' => array(
-				'name' => __('Météo condition j+2', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition j+2', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('string'), 'calcul' => 'text'
 			),
 			'WEATHER_CONDITION_ID_2' => array(
-				'name' => __('Météo condition (id) j+2', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition (id) j+2', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'text'
 			),
 			'WEATHER_TEMPERATURE_MIN_3' => array(
-				'name' => __('Météo Température min j+3', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température min j+3', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MAX_3' => array(
-				'name' => __('Météo Température max j+3', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température max j+3', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_CONDITION_3' => array(
-				'name' => __('Météo condition j+3', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition j+3', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('string'), 'calcul' => 'text'
 			),
 			'WEATHER_CONDITION_ID_3' => array(
-				'name' => __('Météo condition (id) j+3', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition (id) j+3', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'text'
 			),
 			'WEATHER_TEMPERATURE_MIN_4' => array(
-				'name' => __('Météo Température min j+4', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température min j+4', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_TEMPERATURE_MAX_4' => array(
-				'name' => __('Météo Température max j+4', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo Température max j+4', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WEATHER_CONDITION_4' => array(
-				'name' => __('Météo condition j+4', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition j+4', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('string'), 'calcul' => 'text'
 			),
 			'WEATHER_CONDITION_ID_4' => array(
-				'name' => __('Météo condition (id) j+4', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Météo condition (id) j+4', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'text'
 			),
 			'RAIN_CURRENT' => array(
-				'name' => __('Pluie (mm/h)', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Pluie (mm/h)', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'RAIN_TOTAL' => array(
-				'name' => __('Pluie (accumulation)', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Pluie (accumulation)', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WIND_SPEED' => array(
-				'name' => __('Vent (vitesse)', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Vent (vitesse)', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WIND_DIRECTION' => array(
-				'name' => __('Vent (direction)', __FILE__), 'familyid' => 'Weather', 'family' => __('Météo', __FILE__),
+				'name' => new Trad( 'Vent (direction)', __FILE__), 'familyid' => 'Weather', 'family' => new Trad( 'Météo', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'POWER' => array(
-				'name' => __('Puissance Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Puissance Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'CONSUMPTION' => array(
-				'name' => __('Consommation Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Consommation Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'DAILY_CONSUMPTION' => array(
-				'name' => __('Consommation Electrique Journalière', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Consommation Electrique Journalière', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'PRODUCTION' => array(
-				'name' => __('Production Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Production Electrique', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'DAILY_PRODUCTION' => array(
-				'name' => __('Production Electrique Journalière', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Production Electrique Journalière', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric')
 			),
 			'VOLTAGE' => array(
-				'name' => __('Tension', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Tension', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'REBOOT' => array(
-				'name' => __('Redémarrage', __FILE__), 'familyid' => 'Electricity', 'family' => __('Electricité', __FILE__),
+				'name' => new Trad( 'Redémarrage', __FILE__), 'familyid' => 'Electricity', 'family' => new Trad( 'Electricité', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'TEMPERATURE' => array(
-				'name' => __('Température', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Température', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'AIR_QUALITY' => array(
-				'name' => __('Qualité de l\'air', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Qualité de l\'air', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'BRIGHTNESS' => array(
-				'name' => __('Luminosité', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Luminosité', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'PRESENCE' => array(
-				'name' => __('Présence', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Présence', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'SMOKE' => array(
-				'name' => __('Détection de fumée', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Détection de fumée', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'HUMIDITY' => array(
-				'name' => __('Humidité', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Humidité', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'UV' => array(
-				'name' => __('UV', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'UV', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'CO2' => array(
-				'name' => __('CO2 (ppm)', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'CO2 (ppm)', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'CO' => array(
-				'name' => __('CO (ppm)', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'CO (ppm)', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'NOISE' => array(
-				'name' => __('Son (dB)', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Son (dB)', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'PRESSURE' => array(
-				'name' => __('Pression', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Pression', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'WATER_LEAK' => array(
-				'name' => __('Fuite d\'eau', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Fuite d\'eau', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info'
 			),
 			'FILTER_CLEAN_STATE' => array(
-				'name' => __('Etat du filtre', __FILE__), 'familyid' => 'Environment', 'family' => __('Environnement', __FILE__),
+				'name' => new Trad( 'Etat du filtre', __FILE__), 'familyid' => 'Environment', 'family' => new Trad( 'Environnement', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'DEPTH' => array(
-				'name' => __('Profondeur', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => new Trad( 'Profondeur', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'DISTANCE' => array(
-				'name' => __('Distance', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => new Trad( 'Distance', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'BUTTON' => array(
-				'name' => __('Bouton', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => new Trad( 'Bouton', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric')
 			),
 			'GENERIC_INFO' => array(
-				'name' => ' ' . __('Générique', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => ' ' . new Trad( 'Générique', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'Info'
 			),
 			'GENERIC_ACTION' => array(
-				'name' => ' ' . __('Générique', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => ' ' . new Trad( 'Générique', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'Action'
 			),
 			'DONT' => array(
-				'name' => __('Ne pas tenir compte de cette commande', __FILE__), 'familyid' => 'Generic', 'family' => __('Generic', __FILE__),
+				'name' => new Trad( 'Ne pas tenir compte de cette commande', __FILE__), 'familyid' => 'Generic', 'family' => new Trad( 'Generic', __FILE__),
 				'type' => 'All'
 			),
 			'BATTERY' => array(
-				'name' => __('Batterie', __FILE__), 'familyid' => 'Battery', 'family' => __('Batterie', __FILE__),
+				'name' => new Trad( 'Batterie', __FILE__), 'familyid' => 'Battery', 'family' => new Trad( 'Batterie', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'BATTERY_CHARGING' => array(
-				'name' => __('Batterie en charge', __FILE__), 'familyid' => 'Battery', 'family' => __('Batterie', __FILE__),
+				'name' => new Trad( 'Batterie en charge', __FILE__), 'familyid' => 'Battery', 'family' => new Trad( 'Batterie', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'VOLUME' => array(
-				'name' => __('Volume', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Volume', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'MEDIA_STATUS' => array(
-				'name' => __('Status', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Status', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'MEDIA_ALBUM' => array(
-				'name' => __('Album', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Album', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'MEDIA_ARTIST' => array(
-				'name' => __('Artiste', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Artiste', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'MEDIA_TITLE' => array(
-				'name' => __('Titre', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Titre', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'MEDIA_POWER' => array(
-				'name' => __('Power', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Power', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('string')
 			),
 			'SET_VOLUME' => array(
-				'name' => __('Volume', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Volume', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'CHANNEL' => array(
-				'name' => __('Chaine', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Chaine', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric', 'string'), 'calcul' => 'text'
 			),
 			'SET_CHANNEL' => array(
-				'name' => __('Chaine', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Chaine', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other', 'slider')
 			),
 			'MEDIA_PAUSE' => array(
-				'name' => __('Pause', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Pause', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_RESUME' => array(
-				'name' => __('Lecture', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Lecture', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_STOP' => array(
-				'name' => __('Stop', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Stop', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_NEXT' => array(
-				'name' => __('Suivant', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Suivant', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_PREVIOUS' => array(
-				'name' => __('Précedent', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Précedent', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_ON' => array(
-				'name' => __('On', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'On', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_OFF' => array(
-				'name' => __('Off', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Off', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_STATE' => array(
-				'name' => __('Etat', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Etat', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'MEDIA_MUTE' => array(
-				'name' => __('Muet', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Muet', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'MEDIA_UNMUTE' => array(
-				'name' => __('Non Muet', __FILE__), 'familyid' => 'Multimedia', 'family' => __('Multimédia', __FILE__),
+				'name' => new Trad( 'Non Muet', __FILE__), 'familyid' => 'Multimedia', 'family' => new Trad( 'Multimédia', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'FAN_SPEED' => array(
-				'name' => __('Vitesse ventilateur', __FILE__), 'familyid' => 'Fan', 'family' => __('Ventilateur', __FILE__),
+				'name' => new Trad( 'Vitesse ventilateur', __FILE__), 'familyid' => 'Fan', 'family' => new Trad( 'Ventilateur', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'FAN_SPEED_STATE' => array(
-				'name' => __('Vitesse ventilateur Etat', __FILE__), 'familyid' => 'Fan', 'family' => __('Ventilateur', __FILE__),
+				'name' => new Trad( 'Vitesse ventilateur Etat', __FILE__), 'familyid' => 'Fan', 'family' => new Trad( 'Ventilateur', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'ROTATION' => array(
-				'name' => __('Rotation', __FILE__), 'familyid' => 'Fan', 'family' => __('Ventilateur', __FILE__),
+				'name' => new Trad( 'Rotation', __FILE__), 'familyid' => 'Fan', 'family' => new Trad( 'Ventilateur', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'ROTATION_STATE' => array(
-				'name' => __('Rotation Etat', __FILE__), 'familyid' => 'Fan', 'family' => __('Ventilateur', __FILE__),
+				'name' => new Trad( 'Rotation Etat', __FILE__), 'familyid' => 'Fan', 'family' => new Trad( 'Ventilateur', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'DOCK' => array(
-				'name' => __('Retour base', __FILE__), 'familyid' => 'Robot', 'family' => __('Robot', __FILE__),
+				'name' => new Trad( 'Retour base', __FILE__), 'familyid' => 'Robot', 'family' => new Trad( 'Robot', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'DOCK_STATE' => array(
-				'name' => __('Base Etat', __FILE__), 'familyid' => 'Robot', 'family' => __('Robot', __FILE__),
+				'name' => new Trad( 'Base Etat', __FILE__), 'familyid' => 'Robot', 'family' => new Trad( 'Robot', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary')
 			),
 			'TIMER' => array(
-				'name' => __('Minuteur Etat', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Minuteur Etat', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Info', 'subtype' => array('numeric'), 'calcul' => 'avg'
 			),
 			'SET_TIMER' => array(
-				'name' => __('Minuteur', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Minuteur', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Action', 'subtype' => array('slider')
 			),
 			'TIMER_STATE' => array(
-				'name' => __('Minuteur Etat (pause ou non)', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Minuteur Etat (pause ou non)', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Info', 'subtype' => array('binary', 'numeric'), 'calcul' => 'avg'
 			),
 			'TIMER_PAUSE' => array(
-				'name' => __('Minuteur pause', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Minuteur pause', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 			'TIMER_RESUME' => array(
-				'name' => __('Minuteur reprendre', __FILE__), 'familyid' => 'Other', 'family' => __('Autre', __FILE__),
+				'name' => new Trad( 'Minuteur reprendre', __FILE__), 'familyid' => 'Other', 'family' => new Trad( 'Autre', __FILE__),
 				'type' => 'Action', 'subtype' => array('other')
 			),
 		),
 		'type' => array(
 			'info' => array(
-				'name' => __('Info', __FILE__),
+				'name' => new Trad( 'Info', __FILE__),
 				'subtype' => array(
 					'numeric' => array(
-						'name' => __('Numérique', __FILE__),
+						'name' => new Trad( 'Numérique', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => true),
 							'maxValue' => array('visible' => true),
@@ -875,7 +875,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'binary' => array(
-						'name' => __('Binaire', __FILE__),
+						'name' => new Trad( 'Binaire', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -889,7 +889,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'string' => array(
-						'name' => __('Autre', __FILE__),
+						'name' => new Trad( 'Autre', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -905,10 +905,10 @@ $JEEDOM_INTERNAL_CONFIG = array(
 				),
 			),
 			'action' => array(
-				'name' => __('Action', __FILE__),
+				'name' => new Trad( 'Action', __FILE__),
 				'subtype' => array(
 					'other' => array(
-						'name' => __('Défaut', __FILE__),
+						'name' => new Trad( 'Défaut', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -922,7 +922,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'slider' => array(
-						'name' => __('Curseur', __FILE__),
+						'name' => new Trad( 'Curseur', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => true),
 							'maxValue' => array('visible' => true),
@@ -936,7 +936,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'message' => array(
-						'name' => __('Message', __FILE__),
+						'name' => new Trad( 'Message', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -950,7 +950,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'color' => array(
-						'name' => __('Couleur', __FILE__),
+						'name' => new Trad( 'Couleur', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -964,7 +964,7 @@ $JEEDOM_INTERNAL_CONFIG = array(
 						),
 					),
 					'select' => array(
-						'name' => __('Liste', __FILE__),
+						'name' => new Trad( 'Liste', __FILE__),
 						'configuration' => array(
 							'minValue' => array('visible' => false),
 							'maxValue' => array('visible' => false),
@@ -983,41 +983,41 @@ $JEEDOM_INTERNAL_CONFIG = array(
 	),
 );
 $GLOBALS['JEEDOM_SCLOG_TEXT'] = array(
-	'startManual' 			=> array('txt' => __('Scénario lancé manuellement', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'startAutoOnEvent'		=> array('txt' => __('Scénario exécuté automatiquement sur événement venant de :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
-	'startOnEvent'			=> array('txt' => __('Scénario exécuté sur événement', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'startAutoOnShedule'	=> array('txt' => __('Scénario exécuté automatiquement sur programmation', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'finishOk' 				=> array('txt' => __('Fin correcte du scénario', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'sheduledOn'			=> array('txt' => ' ' . __('programmée à :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
-	'startByScenario'		=> array('txt' => __('Lancement provoqué par le scénario  :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
-	'startCausedBy'			=> array('txt' => __('Lancement provoqué', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'startSubTask' 			=> array('txt' => __('************Lancement sous tâche**************', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'endSubTask' 			=> array('txt' => __('************FIN sous tâche**************', __FILE__), 'replace' => '<label class="success">::</label>'),
-	'sheduleNow'			=> array('txt' => ' ' . __('lancement immédiat', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
+	'startManual' 			=> array('txt' => new Trad( 'Scénario lancé manuellement', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'startAutoOnEvent'		=> array('txt' => new Trad( 'Scénario exécuté automatiquement sur événement venant de :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
+	'startOnEvent'			=> array('txt' => new Trad( 'Scénario exécuté sur événement', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'startAutoOnShedule'	=> array('txt' => new Trad( 'Scénario exécuté automatiquement sur programmation', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'finishOk' 				=> array('txt' => new Trad( 'Fin correcte du scénario', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'sheduledOn'			=> array('txt' => ' ' . new Trad( 'programmée à :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
+	'startByScenario'		=> array('txt' => new Trad( 'Lancement provoqué par le scénario  :', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
+	'startCausedBy'			=> array('txt' => new Trad( 'Lancement provoqué', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'startSubTask' 			=> array('txt' => new Trad( '************Lancement sous tâche**************', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'endSubTask' 			=> array('txt' => new Trad( '************FIN sous tâche**************', __FILE__), 'replace' => '<label class="success">::</label>'),
+	'sheduleNow'			=> array('txt' => ' ' . new Trad( 'lancement immédiat', __FILE__) . ' ', 'replace' => '<label class="success">::</label>'),
 
-	'execAction'			=> array('txt' => '- ' . __('Exécution du sous-élément de type [action] :', __FILE__) . ' ', 'replace' => '<label class="info">::</label>'),
-	'execCondition'			=> array('txt' => '- ' . __('Exécution du sous-élément de type [condition] :', __FILE__) . ' ', 'replace' => '<label class="info">::</label>'),
+	'execAction'			=> array('txt' => '- ' . new Trad( 'Exécution du sous-élément de type [action] :', __FILE__) . ' ', 'replace' => '<label class="info">::</label>'),
+	'execCondition'			=> array('txt' => '- ' . new Trad( 'Exécution du sous-élément de type [condition] :', __FILE__) . ' ', 'replace' => '<label class="info">::</label>'),
 
-	'execCmd'				=> array('txt' => __('Exécution de la commande', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'execCode'				=> array('txt' => __('Exécution d\'un bloc code', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'launchScenario'		=> array('txt' => __('Lancement du scénario :', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'launchScenarioSync'	=> array('txt' => __('Lancement du scénario en mode synchrone', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'start'					=> array('txt' => '-- ' . __('Début :', __FILE__), 'replace' => '<strong>::</strong>'),
-	'task'					=> array('txt' => __('Tâche :', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'event'					=> array('txt' => __('Changement de', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
-	'setTag'				=> array('txt' => __('Mise à jour du tag', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'execCmd'				=> array('txt' => new Trad( 'Exécution de la commande', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'execCode'				=> array('txt' => new Trad( 'Exécution d\'un bloc code', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'launchScenario'		=> array('txt' => new Trad( 'Lancement du scénario :', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'launchScenarioSync'	=> array('txt' => new Trad( 'Lancement du scénario en mode synchrone', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'start'					=> array('txt' => '-- ' . new Trad( 'Début :', __FILE__), 'replace' => '<strong>::</strong>'),
+	'task'					=> array('txt' => new Trad( 'Tâche :', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'event'					=> array('txt' => new Trad( 'Changement de', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
+	'setTag'				=> array('txt' => new Trad( 'Mise à jour du tag', __FILE__) . ' ', 'replace' => '<label class="warning">::</label>'),
 
-	'stopTimeout'			=> array('txt' => __('Arrêt du scénario car il a dépassé son temps de timeout :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'disableNoSubtask'		=> array('txt' => __('Scénario désactivé non lancement de la sous tâche', __FILE__), 'replace' => '<label class="danger">::</label>'),
-	'disableEqNoExecCmd'	=> array('txt' => __('Equipement désactivé - impossible d\'exécuter la commande :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'toStartUnfound'		=> array('txt' => __('Eléments à lancer non trouvé', __FILE__), 'replace' => '<label class="danger">::</label>'),
-	'invalideShedule'		=> array('txt' => __(', heure programmée invalide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'noCmdFoundFor'			=> array('txt' => __('[Erreur] Aucune commande trouvée pour', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'unfoundCmd'			=> array('txt' => __('Commande introuvable', __FILE__), 'replace' => '<label class="danger">::</label>'),
-	'unfoundCmdCheckId'		=> array('txt' => __('Commande introuvable - Vérifiez l\'id', __FILE__), 'replace' => '<label class="danger">::</label>'),
-	'unfoundEq'				=> array('txt' => __('Action sur l\'équipement impossible. Equipement introuvable - Vérifiez l\'id :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'unfoundScenario'		=> array('txt' => __('Action sur scénario impossible. Scénario introuvable - Vérifiez l\'id :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'disableScenario'		=> array('txt' => __('Impossible d\'exécuter le scénario :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'invalidExpr'			=> array('txt' => __('Expression non valide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
-	'invalidDuration'		=> array('txt' => __('Aucune durée trouvée pour l\'action sleep ou la durée n\'est pas valide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'stopTimeout'			=> array('txt' => new Trad( 'Arrêt du scénario car il a dépassé son temps de timeout :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'disableNoSubtask'		=> array('txt' => new Trad( 'Scénario désactivé non lancement de la sous tâche', __FILE__), 'replace' => '<label class="danger">::</label>'),
+	'disableEqNoExecCmd'	=> array('txt' => new Trad( 'Equipement désactivé - impossible d\'exécuter la commande :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'toStartUnfound'		=> array('txt' => new Trad( 'Eléments à lancer non trouvé', __FILE__), 'replace' => '<label class="danger">::</label>'),
+	'invalideShedule'		=> array('txt' => new Trad( ', heure programmée invalide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'noCmdFoundFor'			=> array('txt' => new Trad( '[Erreur] Aucune commande trouvée pour', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'unfoundCmd'			=> array('txt' => new Trad( 'Commande introuvable', __FILE__), 'replace' => '<label class="danger">::</label>'),
+	'unfoundCmdCheckId'		=> array('txt' => new Trad( 'Commande introuvable - Vérifiez l\'id', __FILE__), 'replace' => '<label class="danger">::</label>'),
+	'unfoundEq'				=> array('txt' => new Trad( 'Action sur l\'équipement impossible. Equipement introuvable - Vérifiez l\'id :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'unfoundScenario'		=> array('txt' => new Trad( 'Action sur scénario impossible. Scénario introuvable - Vérifiez l\'id :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'disableScenario'		=> array('txt' => new Trad( 'Impossible d\'exécuter le scénario :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'invalidExpr'			=> array('txt' => new Trad( 'Expression non valide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
+	'invalidDuration'		=> array('txt' => new Trad( 'Aucune durée trouvée pour l\'action sleep ou la durée n\'est pas valide :', __FILE__) . ' ', 'replace' => '<label class="danger">::</label>'),
 );

--- a/core/i18n/de_DE.json
+++ b/core/i18n/de_DE.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Nein",
         "Impossible de traduire la couleur en code hexadécimal :": "Farbe kann nicht in hexadezimalen Code übersetzt werden:",
         "Type ou sous-type de commande invalide": "Ungültiger Befehlstyp oder Untertyp",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Der Name des Befehls darf nicht leer sein:",
         "Le type de la commande ne peut pas être vide :": "Der Befehlstyp darf nicht leer sein:",
         "Le sous-type de la commande ne peut pas être vide :": "Der Befehlssubtyp darf nicht leer sein:",

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -4329,6 +4329,7 @@
         "Aucun": "None",
         "Impossible de traduire la couleur en code hexadécimal :": "Unable to translate color into hexadecimal code:",
         "Type ou sous-type de commande invalide": "Invalid command type or subtype",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "The name of the command cannot be empty:",
         "Le type de la commande ne peut pas être vide :": "The type of the command cannot be empty:",
         "Le sous-type de la commande ne peut pas être vide :": "The command subtype cannot be empty:",

--- a/core/i18n/es_ES.json
+++ b/core/i18n/es_ES.json
@@ -4329,6 +4329,7 @@
         "Aucun": "No",
         "Impossible de traduire la couleur en code hexadécimal :": "No se puede traducir el color en código hexadecimal :",
         "Type ou sous-type de commande invalide": "Tipo o subtipo de comando no válido",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "El nombre del comando no puede estar vacío:",
         "Le type de la commande ne peut pas être vide :": "El tipo del comando no puede estar vacío:",
         "Le sous-type de la commande ne peut pas être vide :": "El subtipo de comando no puede estar vacío:",

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Aucun",
         "Impossible de traduire la couleur en code hexadécimal :": "Impossible de traduire la couleur en code hexadécimal :",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement : ",
         "Le nom de la commande ne peut pas être vide :": "Le nom de la commande ne peut pas être vide :",
         "Le type de la commande ne peut pas être vide :": "Le type de la commande ne peut pas être vide :",
         "Le sous-type de la commande ne peut pas être vide :": "Le sous-type de la commande ne peut pas être vide :",

--- a/core/i18n/id_ID.json
+++ b/core/i18n/id_ID.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Tak ada",
         "Impossible de traduire la couleur en code hexadécimal :": "Tidak dapat menerjemahkan warna dalam kode heksadesimal:",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Le nom de la commande ne peut pas être vide :",
         "Le type de la commande ne peut pas être vide :": "Le type de la commande ne peut pas être vide :",
         "Le sous-type de la commande ne peut pas être vide :": "Le sous-type de la commande ne peut pas être vide :",

--- a/core/i18n/it_IT.json
+++ b/core/i18n/it_IT.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Nessuno",
         "Impossible de traduire la couleur en code hexadécimal :": "Impossibile tradurre il colore in codice esadecimale:",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Il nome del comando non può essere vuoto:",
         "Le type de la commande ne peut pas être vide :": "Il tipo di comando non può essere vuoto:",
         "Le sous-type de la commande ne peut pas être vide :": "Il sottotipo di comando non può essere vuoto:",

--- a/core/i18n/ja_JP.json
+++ b/core/i18n/ja_JP.json
@@ -4329,6 +4329,7 @@
         "Aucun": "いいえ",
         "Impossible de traduire la couleur en code hexadécimal :": "進コードで色を変換することができません。",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Le nom de la commande ne peut pas être vide :",
         "Le type de la commande ne peut pas être vide :": "Le type de la commande ne peut pas être vide :",
         "Le sous-type de la commande ne peut pas être vide :": "Le sous-type de la commande ne peut pas être vide :",

--- a/core/i18n/pt_PT.json
+++ b/core/i18n/pt_PT.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Não",
         "Impossible de traduire la couleur en code hexadécimal :": "Incapaz de traduzir cor em código hexadecimal:",
         "Type ou sous-type de commande invalide": "Tipo ou subtipo de comando inválido",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "O nome do comando não pode estar vazio:",
         "Le type de la commande ne peut pas être vide :": "O tipo do comando não pode estar vazio:",
         "Le sous-type de la commande ne peut pas être vide :": "O subtipo de comando não pode estar vazio:",

--- a/core/i18n/ru_RU.json
+++ b/core/i18n/ru_RU.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Нет",
         "Impossible de traduire la couleur en code hexadécimal :": "Невозможно перевести цвет в шестнадцатеричном коде:",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Le nom de la commande ne peut pas être vide :",
         "Le type de la commande ne peut pas être vide :": "Le type de la commande ne peut pas être vide :",
         "Le sous-type de la commande ne peut pas être vide :": "Le sous-type de la commande ne peut pas être vide :",

--- a/core/i18n/tr.json
+++ b/core/i18n/tr.json
@@ -4329,6 +4329,7 @@
         "Aucun": "Hiçbir",
         "Impossible de traduire la couleur en code hexadécimal :": "Renk onaltılık koda çevrilemiyor:",
         "Type ou sous-type de commande invalide": "Type ou sous-type de commande invalide",
+        "La formule de calcul doit retourner une valeur numérique uniquement : ": "La formule de calcul doit retourner une valeur numérique uniquement :",
         "Le nom de la commande ne peut pas être vide :": "Komutun adı boş olamaz:",
         "Le type de la commande ne peut pas être vide :": "Komutun türü boş olamaz:",
         "Le sous-type de la commande ne peut pas être vide :": "Komut alt türü boş bırakılamaz:",

--- a/core/php/authentification.php
+++ b/core/php/authentification.php
@@ -67,7 +67,7 @@ if (!isConnect() && $configs['sso:allowRemoteUser'] == 1) {
 		@session_start();
 		$_SESSION['user'] = $user;
 		@session_write_close();
-		log::add('connection', 'info', __('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $user->getLogin());
+		log::add('connection', 'info', new Trad('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $user->getLogin());
 	}
 }
 
@@ -108,7 +108,7 @@ function login($_login, $_password, $_twoFactor = null) {
 	$_SESSION['user'] = $user;
 	session_regenerate_id(true);
 	@session_write_close();
-	log::add('connection', 'info', __('Connexion de l\'utilisateur :', __FILE__) . ' ' . $_login);
+	log::add('connection', 'info', new Trad('Connexion de l\'utilisateur :', __FILE__) . ' ' . $_login);
 	return true;
 }
 
@@ -147,7 +147,7 @@ function loginByHash($_key) {
 	@session_start();
 	$_SESSION['user'] = $user;
 	@session_write_close();
-	log::add('connection', 'info', __('Connexion de l\'utilisateur par clef :', __FILE__) . ' ' . $user->getLogin());
+	log::add('connection', 'info', new Trad('Connexion de l\'utilisateur par clef :', __FILE__) . ' ' . $user->getLogin());
 	return true;
 }
 

--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -17,17 +17,6 @@
 */
 date_default_timezone_set('Europe/Brussels');
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../config/common.config.php';
-require_once __DIR__ . '/../class/DB.class.php';
-require_once __DIR__ . '/../class/config.class.php';
-require_once __DIR__ . '/../class/jeedom.class.php';
-require_once __DIR__ . '/../class/plugin.class.php';
-require_once __DIR__ . '/../class/translate.class.php';
-require_once __DIR__ . '/utils.inc.php';
-include_file('core', 'jeedom', 'config');
-include_file('core', 'compatibility', 'config');
-include_file('core', 'utils', 'class');
-include_file('core', 'log', 'class');
 
 try {
 	$configs = config::byKeys(array('timezone', 'log::level'));
@@ -46,18 +35,14 @@ try {
 } catch (Error $e) {
 }
 
+/**
+ * Autoload function for specific Jeedom classes
+ * this function is called after the default Composer autoloader
+ * it will load specific classes such as Cmd, Real, etc.
+ * for plugins that do not use namespaces or Composer autoloading
+ */
 function jeedomAutoload($_classname) {
-	/* core class always in /core/class : */
-	$path = __DIR__ . "/../../core/class/$_classname.class.php";
-	if (file_exists($path)) {
-		include_file('core', $_classname, 'class');
-	} else if (substr($_classname, 0, 4) === 'com_') {
-		/* class com_$1 in /core/com/$1.com.php */
-		include_file('core', substr($_classname, 4), 'com');
-	} else if (substr($_classname, 0, 5) === 'repo_') {
-		/* class repo_$1 in /core/repo/$1.repo.php */
-		include_file('core', substr($_classname, 5), 'repo');
-	} else if (strpos($_classname, '\\') === false && strpos($_classname, '/') === false) {
+	if (strpos($_classname, '\\') === false && strpos($_classname, '/') === false) {
 		/* autoload for plugins : no namespace */
 		$classname = str_replace(array('Real', 'Cmd'), '', $_classname);
 		$plugin_active = config::byKey('active', $classname, null);
@@ -69,12 +54,12 @@ function jeedomAutoload($_classname) {
 			try {
 				include_file('core', $classname, 'class', $classname);
 			} catch (Exception $e) {
-				
+				log::add('jeedom', 'error', 'Error loading class ' . $classname . ': ' . $e->getMessage());
 			} catch (Error $e) {
-				
+				log::add('jeedom', 'error', 'Error loading class ' . $classname . ': ' . $e->getMessage());
 			}
 		}
 	}
 }
 
-spl_autoload_register('jeedomAutoload', true, true);
+spl_autoload_register('jeedomAutoload', true, false);

--- a/core/php/downloadFile.php
+++ b/core/php/downloadFile.php
@@ -23,7 +23,7 @@ try {
 	$onlyPluginId = 'all';
 
 	if (!isConnect() && !jeedom::apiAccess(init('apikey'), init('plugin'))) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	//global user created with an api key attached to a user
@@ -40,7 +40,7 @@ try {
 
 	if ($pathfile === false) {
 		log::add('api', 'debug', 'downloadFile - fichier introuvable');
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 
 	if (!$isAdmin) {
@@ -53,12 +53,12 @@ try {
 		}
 		if (!$authorized) {
 			log::add('api', 'debug', 'downloadFile - fichier non accessible en zone blanche');
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 	}
 
 	if (strpos($pathfile, '.php') !== false) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
+		throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 	}
 	$rootPath = realpath(__DIR__ . '/../../');
 	if (strpos($pathfile, $rootPath) === false) {
@@ -68,23 +68,23 @@ try {
 		$adminFiles = array('log', 'backup', '.sql', 'scenario', '.tar', '.gz');
 		foreach ($adminFiles as $adminFile) {
 			if (strpos($pathfile, $adminFile) !== false) {
-				throw new Exception(__('401 - Accès non autorisé', __FILE__));
+				throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 			}
 		}
 	}
 	if (strpos($pathfile, '*') === false) {
 		if (!file_exists($pathfile)) {
-			throw new Exception(__('Fichier non trouvé :', __FILE__) . ' ' . $pathfile);
+			throw new Exception(new Trad('Fichier non trouvé :', __FILE__) . ' ' . $pathfile);
 		}
 	} elseif (is_dir(str_replace('*', '', $pathfile))) {
 		if (!$isAdmin) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz * > /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';
 	} else {
 		if (!$isAdmin) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
+			throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 		}
 		$pattern = array_pop(explode('/', $pathfile));
 		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz ' . $pattern . '> /dev/null 2>&1');

--- a/core/php/export.php
+++ b/core/php/export.php
@@ -19,7 +19,7 @@
 require_once __DIR__ . '/../../core/php/core.inc.php';
 include_file('core', 'authentification', 'php');
 if (!isConnect()) {
-	throw new Exception(__('401 - Accès non autorisé', __FILE__));
+	throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 }
 $type = init('type');
 
@@ -27,7 +27,7 @@ switch ($type) {
 	case 'cmdHistory':
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . init('id'));
 		}
 		header('Content-Type: text/csv; charset=utf-8');
 		header('Content-Disposition: attachment; filename=' . str_replace(' ', '_', $cmd->getHumanName()) . '.csv');
@@ -42,7 +42,7 @@ switch ($type) {
 	case 'eqLogic':
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
-			throw new Exception(__('Commande introuvable :', __FILE__) . ' ' . init('id'));
+			throw new Exception(new Trad('Commande introuvable :', __FILE__) . ' ' . init('id'));
 		}
 		header('Content-Type: text/csv; charset=utf-8');
 		header('Content-Disposition: attachment; filename=' . $eqLogic->getHumanName() . '.json');

--- a/core/php/jeeCron.php
+++ b/core/php/jeeCron.php
@@ -33,11 +33,11 @@ function jeeCron_errorHandler($cron, $class, $function,$datetimeStart, $e) {
 	}
 	echo '[Erreur] ' . $cron->getName() . ' : ' . log::exception($e);
 	if (isset($class) && $class != '') {
-		log::add($class, 'error', __('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
+		log::add($class, 'error', new Trad('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
 	} else if (isset($function) && $function != '') {
-		log::add($function, 'error', __('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
+		log::add($function, 'error', new Trad('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
 	} else {
-		log::add('cron', 'error', __('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
+		log::add('cron', 'error', new Trad('Erreur sur', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e), $logicalId);
 	}
 }
 
@@ -45,14 +45,14 @@ function jeeCronAll_errorHandler($cron, $e) {
 	if ($cron->getOnce() != 1) {
 		$cron->setState('error');
 		$cron->setPID('');
-		echo __('[Erreur master]', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e);
-		log::add('cron', 'error', __('[Erreur master]', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e));
+		echo new Trad('[Erreur master]', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e);
+		log::add('cron', 'error', new Trad('[Erreur master]', __FILE__) . ' ' . $cron->getName() . ' : ' . log::exception($e));
 	}
 }
 
 if (init('cron_id') != '') {
 	if (jeedom::isStarted() && config::byKey('enableCron', 'core', 1, true) == 0) {
-		die(__('Tous les crons sont actuellement désactivés', __FILE__));
+		die(new Trad('Tous les crons sont actuellement désactivés', __FILE__));
 	}
 	$datetime = date('Y-m-d H:i:s');
 	$datetimeStart = strtotime('now');
@@ -105,7 +105,7 @@ if (init('cron_id') != '') {
 				$cron->setState('Not found');
 				$cron->setPID();
 				$cron->setCache('runtime', strtotime('now') - $datetimeStart);
-				log::add('cron', 'error', __('[Erreur] Classe ou fonction non trouvée', __FILE__) . ' ' . $cron->getName());
+				log::add('cron', 'error', new Trad('[Erreur] Classe ou fonction non trouvée', __FILE__) . ' ' . $cron->getName());
 				die();
 			}
 		} else {
@@ -145,7 +145,7 @@ if (init('cron_id') != '') {
 				$cron->setState('Not found');
 				$cron->setPID();
 				$cron->setCache('runtime', strtotime('now') - $datetimeStart);
-				log::add('cron', 'error', __('[Erreur] Non trouvée', __FILE__) . ' ' . $cron->getName());
+				log::add('cron', 'error', new Trad('[Erreur] Non trouvée', __FILE__) . ' ' . $cron->getName());
 				die();
 			}
 		}
@@ -175,7 +175,7 @@ if (init('cron_id') != '') {
 	cron::setPidFile();
 	
 	if ($started && config::byKey('enableCron', 'core', 1, true) == 0) {
-		die(__('Tous les crons sont actuellement désactivés', __FILE__));
+		die(new Trad('Tous les crons sont actuellement désactivés', __FILE__));
 	}
 	$datetime = date('Y-m-d H:i:s');
 	foreach((cron::all()) as $cron) {

--- a/core/php/jeeListener.php
+++ b/core/php/jeeListener.php
@@ -36,11 +36,11 @@ if (init('listener_id') == '') {
 	try {
 		$listener_id = init('listener_id');
 		if ($listener_id == '') {
-			throw new Exception(__('Le listener ID ne peut être vide', __FILE__));
+			throw new Exception(new Trad('Le listener ID ne peut être vide', __FILE__));
 		}
 		$listener = listener::byId($listener_id);
 		if (!is_object($listener)) {
-			throw new Exception(__('Listener non trouvé :', __FILE__) . ' ' . $listener_id);
+			throw new Exception(new Trad('Listener non trouvé :', __FILE__) . ' ' . $listener_id);
 		}
 	} catch (Exception $e) {
 		log::add(init('plugin_id', 'plugin'), 'error', log::exception($e));

--- a/core/php/jeePlugin.php
+++ b/core/php/jeePlugin.php
@@ -36,21 +36,21 @@ try {
 
 	$plugin_id = init('plugin_id');
 	if ($plugin_id == '') {
-		throw new Exception(__('Le plugin ID ne peut être vide', __FILE__));
+		throw new Exception(new Trad('Le plugin ID ne peut être vide', __FILE__));
 	}
 	$plugin = plugin::byId($plugin_id);
 	if (!is_object($plugin)) {
-		throw new Exception(__('Plugin non trouvé :', __FILE__) . ' ' . init('plugin_id'));
+		throw new Exception(new Trad('Plugin non trouvé :', __FILE__) . ' ' . init('plugin_id'));
 	}
 	$function = init('function');
 	if ($function == '') {
-		throw new Exception(__('La fonction ne peut être vide', __FILE__));
+		throw new Exception(new Trad('La fonction ne peut être vide', __FILE__));
 	}
 	if (init('callInstallFunction', 0) == 1) {
 		$plugin->callInstallFunction($function, true);
 	} else {
 		if (!class_exists($plugin_id) || !method_exists($plugin_id, $function)) {
-			throw new Exception(__('Il n\'existe aucune méthode :', __FILE__) . ' ' . $plugin_id . '::' . $function);
+			throw new Exception(new Trad('Il n\'existe aucune méthode :', __FILE__) . ' ' . $plugin_id . '::' . $function);
 		}
 		$plugin_id::$function();
 	}

--- a/core/php/jeeQueue.php
+++ b/core/php/jeeQueue.php
@@ -32,16 +32,16 @@ function jeeQueue_errorHandler($queue, $class, $function,$datetimeStart, $e) {
 	}
 	echo '[Erreur] ' . $queue->getHumanName() . ' : ' . log::exception($e);
 	if (isset($class) && $class != '') {
-		log::add($class, 'error', __('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
+		log::add($class, 'error', new Trad('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
 	} else if (isset($function) && $function != '') {
-		log::add($function, 'error', __('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
+		log::add($function, 'error', new Trad('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
 	} else {
-		log::add('queue', 'error', __('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
+		log::add('queue', 'error', new Trad('Erreur sur', __FILE__) . ' ' . $queue->getHumanName() . ' : ' . log::exception($e), $logicalId);
 	}
 }
 
 if (jeedom::isStarted() && config::byKey('enableQueue', 'core', 1, true) == 0) {
-    die(__('Tous les queues sont actuellement désactivés', __FILE__));
+    die(new Trad('Tous les queues sont actuellement désactivés', __FILE__));
 }
 $datetime = date('Y-m-d H:i:s');
 $datetimeStart = strtotime('now');
@@ -60,7 +60,7 @@ try {
             try {
                 call_user_func_array($queue->getClass() . '::' . $queue->getFunction(), $queue->getArguments());
             } catch (\Throwable $th) {
-                log::add('queue', 'error', __('[Erreur] ', __FILE__) . ' ' . $queue->getHumanName().' => '.$th->getMessage());
+                log::add('queue', 'error', new Trad('[Erreur] ', __FILE__) . ' ' . $queue->getHumanName().' => '.$th->getMessage());
                 $queue->setState('error');
                 $queue->setPID();
                 $queue->setCache('numberFailed',$queue->getCache('numberFailed',0)+1);
@@ -69,7 +69,7 @@ try {
         } else {
             $queue->setState('Not found');
             $queue->setPID();
-            log::add('queue', 'error', __('[Erreur] Non trouvée', __FILE__) . ' ' . $queue->getHumanName());
+            log::add('queue', 'error', new Trad('[Erreur] Non trouvée', __FILE__) . ' ' . $queue->getHumanName());
             die();
         }
     } else {
@@ -77,7 +77,7 @@ try {
             try {
                 call_user_func_array($queue->getFunction(), $queue->getArguments());
             } catch (\Throwable $th) {
-                log::add('queue', 'error', __('[Erreur] ', __FILE__) . ' ' . $queue->getHumanName().' => '.$th->getMessage());
+                log::add('queue', 'error', new Trad('[Erreur] ', __FILE__) . ' ' . $queue->getHumanName().' => '.$th->getMessage());
                 $queue->setState('error');
                 $queue->setPID();
                 $queue->setCache('numberFailed',$queue->getCache('numberFailed',0)+1);
@@ -86,7 +86,7 @@ try {
         } else {
             $queue->setState('Not found');
             $queue->setPID();
-            log::add('queue', 'error', __('[Erreur] Non trouvée', __FILE__) . ' ' . $queue->getHumanName());
+            log::add('queue', 'error', new Trad('[Erreur] Non trouvée', __FILE__) . ' ' . $queue->getHumanName());
             die();
         }
     }

--- a/core/php/jeeScenario.php
+++ b/core/php/jeeScenario.php
@@ -29,13 +29,13 @@ if (init('scenarioElement_id') != '') {
 	try {
 		$scenario = scenario::byId(init('scenario_id'));
 	} catch (Error $e) {
-		log::add('scenario', 'error', __('Scenario  :', __FILE__) . ' ' . init('scenario_id') . '. ' . __('Erreur :', __FILE__) . ' ' . log::exception($e));
+		log::add('scenario', 'error', new Trad('Scenario  :', __FILE__) . ' ' . init('scenario_id') . '. ' . new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		cache::set('scenarioCacheAttr' . init('scenario_id'), utils::setJsonAttr(cache::byKey('scenarioCacheAttr' . init('scenario_id'))->getValue(), 'state', 'error'));
 		die();
 	}
 	if (!is_object($scenario)) {
-		log::add('scenario', 'info', __('Scénario non trouvé. Vérifiez ID :', __FILE__) . ' ' . init('scenario_id'));
-		die(__('Scénario non trouvé. Vérifiez ID :', __FILE__) . ' ' . init('scenario_id'));
+		log::add('scenario', 'info', new Trad('Scénario non trouvé. Vérifiez ID :', __FILE__) . ' ' . init('scenario_id'));
+		die(new Trad('Scénario non trouvé. Vérifiez ID :', __FILE__) . ' ' . init('scenario_id'));
 	}
 	if (is_numeric($scenario->getTimeout()) && $scenario->getTimeout() != '' && $scenario->getTimeout() != 0) {
 		set_time_limit($scenario->getTimeout(config::byKey('maxExecTimeScript', 'core', 1) * 60));
@@ -49,16 +49,16 @@ if (init('scenarioElement_id') != '') {
 		}
 		$scenario->execute(init('intance_id'));
 	} catch (Exception $e) {
-		log::add('scenario', 'error', __('Scenario  :', __FILE__) . ' ' . $scenario->getHumanName() . '. ' . __('Erreur :', __FILE__) . ' ' . log::exception($e));
+		log::add('scenario', 'error', new Trad('Scenario  :', __FILE__) . ' ' . $scenario->getHumanName() . '. ' . new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		$scenario->setState('error');
-		$scenario->setLog(__('Erreur :', __FILE__) . ' ' . log::exception($e));
+		$scenario->setLog(new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		$scenario->setPID('');
 		$scenario->persistLog();
 		die();
 	}catch (Error $e) {
-		log::add('scenario', 'error', __('Scenario  :', __FILE__) . ' ' . $scenario->getHumanName() . '. ' . __('Erreur :', __FILE__) . ' ' . log::exception($e));
+		log::add('scenario', 'error', new Trad('Scenario  :', __FILE__) . ' ' . $scenario->getHumanName() . '. ' . new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		$scenario->setState('error');
-		$scenario->setLog(__('Erreur :', __FILE__) . ' ' . log::exception($e));
+		$scenario->setLog(new Trad('Erreur :', __FILE__) . ' ' . log::exception($e));
 		$scenario->setPID('');
 		$scenario->persistLog();
 		die();

--- a/core/php/jeeScenarioExpression.php
+++ b/core/php/jeeScenarioExpression.php
@@ -26,7 +26,7 @@ require_once __DIR__ . "/core.inc.php";
 $cache = cache::byKey(init('key'))->getValue();
 if (!isset($cache['scenarioExpression'])) {
 	if ($cache['scenario'] !== null) {
-		$cache['scenario']->setLog(__('Lancement en arrière-plan non trouvé :', __FILE__) . ' ' . init('key'));
+		$cache['scenario']->setLog(new Trad('Lancement en arrière-plan non trouvé :', __FILE__) . ' ' . init('key'));
 		$cache['scenario']->persistLog();
 	}
 	die();
@@ -37,7 +37,7 @@ if (!isset($cache['scenario'])) {
 cache::byKey(init('key'))->remove();
 if ($cache['scenario'] != null) {
 	$cache['scenario']->clearLog();
-	$cache['scenario']->setLog(__('Lancement en arrière-plan de :', __FILE__) . ' ' . init('key'));
+	$cache['scenario']->setLog(new Trad('Lancement en arrière-plan de :', __FILE__) . ' ' . init('key'));
 }
 $cache['scenarioExpression']->setOptions('background', 0);
 $cache['scenarioExpression']->execute($cache['scenario']);

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1839,3 +1839,10 @@ function implode_recursive($_array, $_separator, $_key = '') {
 	}
 	return $result;
 }
+
+/**
+ * alias for translate::sentence
+ */
+function __($_content, $_name, $_backslash = false) {
+	return translate::sentence(str_replace("\'", "'", $_content), $_name, $_backslash);
+}

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -73,7 +73,7 @@ function include_file($_folder, $_fn, $_type, $_plugin = '') {
 	}
 	$path = __DIR__ . '/../../' . $_folder . '/' . $_fn;
 	if (!file_exists($path) && $type == 'php') {
-		throw new Exception(__('Fichier introuvable :', __FILE__) . ' ' . secureXSS($path), 35486);
+		throw new Exception(new Trad('Fichier introuvable :', __FILE__) . ' ' . secureXSS($path), 35486);
 	}
 	if ($type == 'php') {
 		if ($_type != 'class') {
@@ -1583,7 +1583,7 @@ function listSession() {
 	$return = array();
 	$sessions = explode("\n", com_shell::execute(system::getCmdSudo() . ' ls -t ' . session_save_path()));
 	if (count($sessions) > 100) {
-		throw new Exception(__('Trop de sessions, je ne peux pas lister :', __FILE__) . ' ' . count($sessions) . __('. Faire, pour les nettoyer :', __FILE__) . ' ' . '"sudo rm -rf ' . session_save_path() . ';sudo mkdir ' . session_save_path() . ';sudo chmod 777 ' . session_save_path() . '"');
+		throw new Exception(new Trad('Trop de sessions, je ne peux pas lister :', __FILE__) . ' ' . count($sessions) . new Trad('. Faire, pour les nettoyer :', __FILE__) . ' ' . '"sudo rm -rf ' . session_save_path() . ';sudo mkdir ' . session_save_path() . ';sudo chmod 777 ' . session_save_path() . '"');
 	}
 	foreach ($sessions as $session) {
 		try {
@@ -1628,7 +1628,7 @@ function unautorizedInDemo($_user = null) {
 		return;
 	}
 	if ($_user->getLogin() == 'demo') {
-		throw new Exception(__('Cette action n\'est pas autorisée en mode démo', __FILE__));
+		throw new Exception(new Trad('Cette action n\'est pas autorisée en mode démo', __FILE__));
 	}
 }
 
@@ -1694,82 +1694,82 @@ function getTZoffsetMin() {
 function pageTitle($_page) {
 	switch ($_page) {
 		case 'overview':
-			$return = __('Synthèse', __FILE__);
+			$return = new Trad('Synthèse', __FILE__);
 			break;
 		case 'view':
-			$return = __('Vues', __FILE__);
+			$return = new Trad('Vues', __FILE__);
 			break;
 		case 'plan':
-			$return = __('Designs', __FILE__);
+			$return = new Trad('Designs', __FILE__);
 			break;
 		case 'plan3d':
-			$return = __('Designs 3D', __FILE__);
+			$return = new Trad('Designs 3D', __FILE__);
 			break;
 		case 'eqAnalyse':
-			$return = __('Equipements', __FILE__);
+			$return = new Trad('Equipements', __FILE__);
 			break;
 		case 'display':
-			$return = __('Résumé', __FILE__);
+			$return = new Trad('Résumé', __FILE__);
 			break;
 		case 'history':
-			$return = __('Historique', __FILE__);
+			$return = new Trad('Historique', __FILE__);
 			break;
 		case 'timeline':
-			$return = __('Timeline', __FILE__);
+			$return = new Trad('Timeline', __FILE__);
 			break;
 		case 'report':
-			$return = __('Rapports', __FILE__);
+			$return = new Trad('Rapports', __FILE__);
 			break;
 		case 'replace':
-			$return = __('Remplacement', __FILE__);
+			$return = new Trad('Remplacement', __FILE__);
 			break;
 		case 'health':
-			$return = __('Santé', __FILE__);
+			$return = new Trad('Santé', __FILE__);
 			break;
 		case 'object':
-			$return = __('Objets', __FILE__);
+			$return = new Trad('Objets', __FILE__);
 			break;
 		case 'scenario':
-			$return = __('Scénarios', __FILE__);
+			$return = new Trad('Scénarios', __FILE__);
 			break;
 		case 'interact':
-			$return = __('Interactions', __FILE__);
+			$return = new Trad('Interactions', __FILE__);
 			break;
 		case 'widgets':
-			$return = __('Widgets', __FILE__);
+			$return = new Trad('Widgets', __FILE__);
 			break;
 		case 'plugin':
-			$return = __('Gestion Plugins', __FILE__);
+			$return = new Trad('Gestion Plugins', __FILE__);
 			break;
 		case 'backup':
-			$return = __('Sauvegardes', __FILE__);
+			$return = new Trad('Sauvegardes', __FILE__);
 			break;
 		case 'administration':
-			$return = __('Configuration', __FILE__);
+			$return = new Trad('Configuration', __FILE__);
 			break;
 		case 'database':
-			$return = __('Base de données', __FILE__);
+			$return = new Trad('Base de données', __FILE__);
 			break;
 		case 'massedit':
-			$return = __('Editeur en masse', __FILE__);
+			$return = new Trad('Editeur en masse', __FILE__);
 			break;
 		case 'cron':
-			$return = __('Moteur de tâches', __FILE__);
+			$return = new Trad('Moteur de tâches', __FILE__);
 			break;
 		case 'custom':
-			$return = __('Personnalisation', __FILE__);
+			$return = new Trad('Personnalisation', __FILE__);
 			break;
 		case 'user':
-			$return = __('Utilisateurs', __FILE__);
+			$return = new Trad('Utilisateurs', __FILE__);
 			break;
 		case 'profils':
-			$return = __('Préférences', __FILE__);
+			$return = new Trad('Préférences', __FILE__);
 			break;
 		case 'log':
-			$return = __('Logs', __FILE__);
+			$return = new Trad('Logs', __FILE__);
 			break;
 		case 'update':
-			$return = __('Mises à jour', __FILE__);
+			$return = new Trad('Mises à jour', __FILE__);
 			break;
 		case 'panel':
 			try {
@@ -1777,13 +1777,13 @@ function pageTitle($_page) {
 					$url = $_SERVER['REQUEST_URI'];
 					$plugin = explode('m=', $url)[1];
 					$plugin = explode('&', $plugin)[0];
-					$return = __('Panel', __FILE__) . ' ' . ucfirst($plugin);
+					$return = new Trad('Panel', __FILE__) . ' ' . ucfirst($plugin);
 				} else {
-					$return = __('Panel', __FILE__);
+					$return = new Trad('Panel', __FILE__);
 				}
 				break;
 			} catch (Exception $e) {
-				$return = __('Panel', __FILE__);
+				$return = new Trad('Panel', __FILE__);
 				break;
 			}
 		default:
@@ -1841,7 +1841,8 @@ function implode_recursive($_array, $_separator, $_key = '') {
 }
 
 /**
- * alias for translate::sentence
+ * @deprecated : alias for translate::sentence
+ * use: `new Trad( 'content, __FILE__)`
  */
 function __($_content, $_name, $_backslash = false) {
 	return translate::sentence(str_replace("\'", "'", $_content), $_name, $_backslash);

--- a/core/repo/file.repo.php
+++ b/core/repo/file.repo.php
@@ -35,10 +35,10 @@ class repo_file {
 
 	public static function getConfigurationOption(){
 		return array(
-          	'translate_name' => __('Fichier',__FILE__),
+          	'translate_name' => new Trad('Fichier', __FILE__),
 			'parameters_for_add' => array(
 				'path' => array(
-					'name' =>  __('Chemin',__FILE__),
+					'name' =>  new Trad('Chemin', __FILE__),
 					'type' => 'file',
 				),
 			),

--- a/core/repo/github.repo.php
+++ b/core/repo/github.repo.php
@@ -39,40 +39,40 @@ class repo_github {
 		return array(
 			'parameters_for_add' => array(
 				'user' => array(
-					'name' =>  __('Utilisateur ou organisation du dépôt',__FILE__),
+					'name' =>  new Trad('Utilisateur ou organisation du dépôt', __FILE__),
 					'type' => 'input',
 				),
 				'repository' => array(
-					'name' =>  __('Nom du dépôt',__FILE__),
+					'name' =>  new Trad('Nom du dépôt', __FILE__),
 					'type' => 'input',
 				),
 				'token' => array(
-					'name' =>  __('Token (facultatif)',__FILE__),
+					'name' =>  new Trad('Token (facultatif)', __FILE__),
 					'type' => 'input'
 				),
 				'version' => array(
-					'name' =>  __('Branche',__FILE__),
+					'name' =>  new Trad('Branche', __FILE__),
 					'type' => 'input',
 					'default' => 'master',
 				),
 			),
 			'configuration' => array(
 				'token' => array(
-					'name' =>  __('Token (facultatif)',__FILE__),
+					'name' =>  new Trad('Token (facultatif)', __FILE__),
 					'type' => 'input',
 				),
 				'core::user' => array(
-					'name' =>  __('Utilisateur ou organisation du dépôt pour le core Jeedom',__FILE__),
+					'name' =>  new Trad('Utilisateur ou organisation du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'jeedom',
 				),
 				'core::repository' => array(
-					'name' =>  __('Nom du dépôt pour le core Jeedom',__FILE__),
+					'name' =>  new Trad('Nom du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'core',
 				),
 				'core::branch' => array(
-					'name' =>  __('Branche pour le core Jeedom',__FILE__),
+					'name' =>  new Trad('Branche pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'stable',
 				),
@@ -136,10 +136,10 @@ class repo_github {
 			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
+			throw new Exception(new Trad('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . new Trad('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
 		$url = 'https://api.github.com/repos/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/zipball/' . $_update->getConfiguration('version', 'master');
-		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $_update->getLogicalId() . '...');
+		log::add('update', 'alert', new Trad('Téléchargement de', __FILE__) . ' ' . $_update->getLogicalId() . '...');
 		if ($token == '') {
 			$result = shell_exec('curl -s -L ' . $url . ' > ' . $tmp);
 		} else {
@@ -166,7 +166,7 @@ class repo_github {
 	
 	public static function downloadCore($_path) {
 		$url = 'https://api.github.com/repos/' . config::byKey('github::core::user', 'core', 'jeedom') . '/' . config::byKey('github::core::repository', 'core', 'core') . '/zipball/' . config::byKey('github::core::branch', 'core', 'stable');
-		echo __('Téléchargement de', __FILE__) . ' ' . $url . '...';
+		echo new Trad('Téléchargement de', __FILE__) . ' ' . $url . '...';
 		if (config::byKey('github::token') == '') {
 			echo shell_exec('curl -s -L ' . $url . ' > ' . $_path);
 		} else {

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -72,41 +72,41 @@ class repo_market {
 		return array(
 			'configuration' => array(
 				'address' => array(
-					'name' => __('Adresse', __FILE__),
+					'name' => new Trad('Adresse', __FILE__),
 					'type' => 'input',
 				),
 				'username' => array(
-					'name' => __('Nom d\'utilisateur', __FILE__),
+					'name' => new Trad('Nom d\'utilisateur', __FILE__),
 					'type' => 'input',
 				),
 				'password' => array(
-					'name' => __('Mot de passe', __FILE__),
+					'name' => new Trad('Mot de passe', __FILE__),
 					'type' => 'password_noshow',
 				),
 				'no_ssl_verify' => array(
-					'name' => __('Pas de validation SSL (non recommandé)', __FILE__),
+					'name' => new Trad('Pas de validation SSL (non recommandé)', __FILE__),
 					'type' => 'checkbox',
 				),
 				'cloud::backup::name' => array(
-					'name' => __('[Backup cloud] Nom du dossier de backup', __FILE__),
+					'name' => new Trad('[Backup cloud] Nom du dossier de backup', __FILE__),
 					'type' => 'input',
 				),
 				'cloud::backup::password' => array(
-					'name' => __('[Backup cloud] Mot de passe', __FILE__),
+					'name' => new Trad('[Backup cloud] Mot de passe', __FILE__),
 					'type' => 'password',
 				),
 				'cloud::backup::password_confirmation' => array(
-					'name' => __('[Backup cloud] Mot de passe (confirmation)', __FILE__),
+					'name' => new Trad('[Backup cloud] Mot de passe (confirmation)', __FILE__),
 					'type' => 'password',
 				),
 				'cloud::monitoring::disable' => array(
-					'name' => __('[Monitoring cloud] Désactiver', __FILE__),
+					'name' => new Trad('[Monitoring cloud] Désactiver', __FILE__),
 					'type' => 'checkbox',
 				)
 			),
 			'parameters_for_add' => array(
 				'version' => array(
-					'name' => __('Version : beta, stable', __FILE__),
+					'name' => new Trad('Version : beta, stable', __FILE__),
 					'type' => 'input',
 				),
 			),
@@ -134,7 +134,7 @@ class repo_market {
 				if (!is_object($repo)) {
 					continue;
 				}
-				log::add('market', 'debug', __('Lancement de l\'installation de', __FILE__) . ' ' . $repo->getLogicalId() . ' ' . __('en version', __FILE__) . ' ' . $plugin['version']);
+				log::add('market', 'debug', new Trad('Lancement de l\'installation de', __FILE__) . ' ' . $repo->getLogicalId() . ' ' . new Trad('en version', __FILE__) . ' ' . $plugin['version']);
 				$update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
 				if (!is_object($update)) {
 					$update = new update();
@@ -194,7 +194,7 @@ class repo_market {
 		if (is_object($market)) {
 			$file = $market->install($_update->getConfiguration('version', 'stable'));
 		} else {
-			throw new Exception(__('Objet introuvable sur le market :', __FILE__) . ' ' . $_update->getLogicalId() . '/' . $_update->getType());
+			throw new Exception(new Trad('Objet introuvable sur le market :', __FILE__) . ' ' . $_update->getLogicalId() . '/' . $_update->getType());
 		}
 		return array('path' => $file, 'localVersion' => $market->getDatetime($_update->getConfiguration('version', 'stable')));
 	}
@@ -263,13 +263,13 @@ class repo_market {
 
 	public static function backup_send($_path) {
 		if (!config::byKey('service::backup::enable')) {
-			throw new Exception(__('Erreur d\'envoi du backup au cloud. Avez-vous bien un abonnement au backup cloud ?', __FILE__));
+			throw new Exception(new Trad('Erreur d\'envoi du backup au cloud. Avez-vous bien un abonnement au backup cloud ?', __FILE__));
 		}
 		if (config::byKey('market::cloud::backup::password') == '') {
-			throw new Exception(__('Vous devez obligatoirement avoir un mot de passe pour le backup cloud (allez dans Réglages -> Système -> Configuration puis onglet Mise à jour/Market)', __FILE__));
+			throw new Exception(new Trad('Vous devez obligatoirement avoir un mot de passe pour le backup cloud (allez dans Réglages -> Système -> Configuration puis onglet Mise à jour/Market)', __FILE__));
 		}
 		if (config::byKey('market::cloud::backup::password') != config::byKey('market::cloud::backup::password_confirmation')) {
-			throw new Exception(__('Le mot de passe du backup cloud n\'est pas identique à la confirmation', __FILE__));
+			throw new Exception(new Trad('Le mot de passe du backup cloud n\'est pas identique à la confirmation', __FILE__));
 		}
 		self::backup_clean($_path);
 		self::backup_createFolderIsNotExist();
@@ -322,7 +322,7 @@ class repo_market {
 		if (($total_size / 1024 / 1024) < $limit - (filesize($_path) / 1024 / 1024)) {
 			return;
 		}
-		echo __('Besoin de faire de la place sur le stockage distant', __FILE__) . "\n";
+		echo new Trad('Besoin de faire de la place sur le stockage distant', __FILE__) . "\n";
 		if (!empty($files)) {
 			usort($files, function ($a, $b) {
 				return $a["timestamp"] - $b["timestamp"];
@@ -331,10 +331,10 @@ class repo_market {
 		$nb = 0;
 		while (($total_size / 1024 / 1024) > $limit - (filesize($_path) / 1024 / 1024)) {
 			if (count($files) == 0) {
-				throw new \Exception(__('Pas assez de place et aucun backup à supprimer', __FILE__));
+				throw new \Exception(new Trad('Pas assez de place et aucun backup à supprimer', __FILE__));
 			}
 			$file = array_shift($files);
-			echo __('Supression du backup cloud :', __FILE__) . ' ' . $file['name'] . "\n";
+			echo new Trad('Supression du backup cloud :', __FILE__) . ' ' . $file['name'] . "\n";
 			$request_http = new com_http($file['href'],config::byKey('market::username'),config::byKey('market::password'));
 			$request_http->setCURLOPT(array(
 					CURLOPT_CUSTOMREQUEST => "DELETE"
@@ -343,7 +343,7 @@ class repo_market {
 			$total_size -= $file['size'];
 			$nb++;
 			if ($nb > 100) {
-				throw new \Exception(__('Erreur lors du nettoyage des backups cloud, supression > 100', __FILE__));
+				throw new \Exception(new Trad('Erreur lors du nettoyage des backups cloud, supression > 100', __FILE__));
 			}
 		}
 	}
@@ -383,7 +383,7 @@ class repo_market {
 
 	public static function backup_restore($_backup) {
 		if (config::byKey('market::cloud::backup::password') != config::byKey('market::cloud::backup::password_confirmation')) {
-			throw new Exception(__('Le mot de passe du backup cloud n\'est pas identique à la confirmation', __FILE__));
+			throw new Exception(new Trad('Le mot de passe du backup cloud n\'est pas identique à la confirmation', __FILE__));
 		}
 		$backup_dir = calculPath(config::byKey('backup::path'));
 		if (!file_exists($backup_dir)) {
@@ -445,10 +445,10 @@ class repo_market {
 						$result = json_decode($request_http->exec(60, 1), true);
 					}
 					if ($result == null || $result['state'] != 'ok') {
-						log::add('monitoring_cloud', 'debug', __('Erreur sur le monitoring cloud :', __FILE__) . ' ' . json_encode($result));
+						log::add('monitoring_cloud', 'debug', new Trad('Erreur sur le monitoring cloud :', __FILE__) . ' ' . json_encode($result));
 					}
 				} catch (\Exception $e) {
-					log::add('monitoring_cloud', 'debug', __('Erreur sur le monitoring cloud :', __FILE__) . ' ' . $e->getMessage());
+					log::add('monitoring_cloud', 'debug', new Trad('Erreur sur le monitoring cloud :', __FILE__) . ' ' . $e->getMessage());
 				}
 			}
 		} catch (Exception $e) {
@@ -513,10 +513,10 @@ class repo_market {
 						$return['status'] = 'ok';
 					}
 				} catch (Exception $e) {
-					log::add('market', 'debug', __('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
+					log::add('market', 'debug', new Trad('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
 					$return['status'] = 'ok';
 				} catch (Error $e) {
-					log::add('market', 'debug', __('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
+					log::add('market', 'debug', new Trad('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
 					$return['status'] = 'ok';
 				}
 				$returns[$logicalId] = $return;
@@ -564,10 +564,10 @@ class repo_market {
 				}
 			}
 		} catch (Exception $e) {
-			log::add('market', 'debug', __('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
+			log::add('market', 'debug', new Trad('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
 			$return['status'] = 'ok';
 		} catch (Error $e) {
-			log::add('market', 'debug', __('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
+			log::add('market', 'debug', new Trad('Erreur repo_market::getinfo :', __FILE__) . ' ' . $e->getMessage());
 			$return['status'] = 'ok';
 		}
 		return $return;
@@ -953,7 +953,7 @@ class repo_market {
 			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
+			throw new Exception(new Trad('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . new Trad('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
 
 		$url = config::byKey('market::address') . "/core/php/downloadFile.php?id=" . $this->getId();
@@ -964,20 +964,20 @@ class repo_market {
 		$url .='&username=' . urlencode(config::byKey('market::username'));
 		$url .='&password=' . self::getPassword();
 		$url .='&password_type=sha1';
-		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $this->getLogicalId() . '...');
-		log::add('update', 'alert', __('URL', __FILE__) . ' ' . $url);
+		log::add('update', 'alert', new Trad('Téléchargement de', __FILE__) . ' ' . $this->getLogicalId() . '...');
+		log::add('update', 'alert', new Trad('URL', __FILE__) . ' ' . $url);
 		exec('wget "' . $url . '" -O ' . $tmp . ' >> ' . log::getPathToLog('update') . ' 2>&1');
 		switch ($this->getType()) {
 			case 'plugin':
 				return $tmp;
 				break;
 			default:
-				log::add('update', 'alert', __('Installation des plugin, widget, scénario...', __FILE__));
+				log::add('update', 'alert', new Trad('Installation des plugin, widget, scénario...', __FILE__));
 				$type = $this->getType();
 				if (class_exists($type) && method_exists($type, 'getFromMarket')) {
 					$type::getFromMarket($this, $tmp);
 				}
-				log::add('update', 'alert', __("OK\n", __FILE__));
+				log::add('update', 'alert', new Trad("OK\n", __FILE__));
 				break;
 		}
 		return false;
@@ -1031,24 +1031,24 @@ class repo_market {
 				$tmp = jeedom::getTmpFolder('market') . '/' . $plugin_id . '.zip';
 				if (file_exists($tmp)) {
 					if (!unlink($tmp)) {
-						throw new Exception(__('Impossible de supprimer :', __FILE__) . ' ' . $tmp . __('. Vérifiez les droits', __FILE__));
+						throw new Exception(new Trad('Impossible de supprimer :', __FILE__) . ' ' . $tmp . new Trad('. Vérifiez les droits', __FILE__));
 					}
 				}
 				if (!create_zip($cibDir, $tmp)) {
-					throw new Exception(__('Echec de création de l\'archive zip', __FILE__));
+					throw new Exception(new Trad('Echec de création de l\'archive zip', __FILE__));
 				}
 				rrmdir($cibDir);
 				break;
 			default:
 				$type = $this->getType();
 				if (!class_exists($type) || !method_exists($type, 'shareOnMarket')) {
-					throw new Exception(__('Aucune fonction correspondante à :', __FILE__) . ' ' . $type . '::shareOnMarket');
+					throw new Exception(new Trad('Aucune fonction correspondante à :', __FILE__) . ' ' . $type . '::shareOnMarket');
 				}
 				$tmp = $type::shareOnMarket($this);
 				break;
 		}
 		if (!file_exists($tmp)) {
-			throw new Exception(__('Impossible de trouver le fichier à envoyer :', __FILE__) . ' ' . $tmp);
+			throw new Exception(new Trad('Impossible de trouver le fichier à envoyer :', __FILE__) . ' ' . $tmp);
 		}
 		$file = array(
 			'file' => '@' . realpath($tmp),

--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -40,29 +40,29 @@ class repo_samba {
 		return array(
 			'parameters_for_add' => array(
 				'path' => array(
-					'name' => __('Chemin', __FILE__),
+					'name' => new Trad('Chemin', __FILE__),
 					'type' => 'input',
 				),
 			),
 			'configuration' => array(
 				'backup::ip' => array(
-					'name' => __('[Backup] IP', __FILE__),
+					'name' => new Trad('[Backup] IP', __FILE__),
 					'type' => 'input',
 				),
 				'backup::username' => array(
-					'name' => __('[Backup] Utilisateur', __FILE__),
+					'name' => new Trad('[Backup] Utilisateur', __FILE__),
 					'type' => 'input',
 				),
 				'backup::password' => array(
-					'name' => __('[Backup] Mot de passe', __FILE__),
+					'name' => new Trad('[Backup] Mot de passe', __FILE__),
 					'type' => 'password',
 				),
 				'backup::share' => array(
-					'name' => __('[Backup] Partage', __FILE__),
+					'name' => new Trad('[Backup] Partage', __FILE__),
 					'type' => 'input',
 				),
 				'backup::folder' => array(
-					'name' => __('[Backup] Chemin', __FILE__),
+					'name' => new Trad('[Backup] Chemin', __FILE__),
 					'type' => 'input',
 				),
 			),
@@ -109,7 +109,7 @@ class repo_samba {
 			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
+			throw new Exception(new Trad('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . new Trad('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
 		$cmd = 'cd ' . $tmp_dir . ';';
 		$cmd .= self::makeSambaCommand('cd ' . config::byKey('samba::plugin::folder') . ';get ' . $_update->getConfiguration('path'), 'plugin');

--- a/core/repo/url.repo.php
+++ b/core/repo/url.repo.php
@@ -38,17 +38,17 @@ class repo_url {
 		return array(
 			'parameters_for_add' => array(
 				'url' => array(
-					'name' => __('URL du fichier ZIP',__FILE__),
+					'name' => new Trad('URL du fichier ZIP', __FILE__),
 					'type' => 'input',
 				),
 			),
 			'configuration' => array(
 				'core::url' => array(
-					'name' => __('URL core Jeedom',__FILE__),
+					'name' => new Trad('URL core Jeedom', __FILE__),
 					'type' => 'input',
 				),
 				'core::version' => array(
-					'name' => __('URL version core Jeedom',__FILE__),
+					'name' => new Trad('URL version core Jeedom', __FILE__),
 					'type' => 'input',
 				),
 			),
@@ -69,7 +69,7 @@ class repo_url {
 			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
+			throw new Exception(new Trad('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . new Trad('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
 		$result = exec('wget --no-check-certificate --progress=dot --dot=mega ' . $_update->getConfiguration('url') . ' -O ' . $tmp);
 		log::add('update', 'alert', $result);

--- a/desktop/modal/cmd.selectMultiple.php
+++ b/desktop/modal/cmd.selectMultiple.php
@@ -25,7 +25,7 @@ if (is_object($cmd)) {
   $listeCmds = cmd::byTypeSubType(init('type'), init('subtype'));
 }
 if (!is_array($listeCmds) || count($listeCmds) == 0) {
-  throw new Exception(__('Aucune commande trouvée', __FILE__));
+  throw new Exception(new Trad('Aucune commande trouvée', __FILE__));
 }
 ?>
 

--- a/desktop/modal/object.display.php
+++ b/desktop/modal/object.display.php
@@ -20,20 +20,20 @@ if (!isConnect('admin')) {
 }
 $class = init('class');
 if ($class == '' || !class_exists($class)) {
-  throw new Exception(__('La classe demandée n\'existe pas :', __FILE__) . ' ' . $class);
+  throw new Exception(new Trad('La classe demandée n\'existe pas :', __FILE__) . ' ' . $class);
 }
 if (!method_exists($class, 'byId')) {
-  throw new Exception(__('La classe demandée n\'a pas de méthode byId :', __FILE__) . ' ' . $class);
+  throw new Exception(new Trad('La classe demandée n\'a pas de méthode byId :', __FILE__) . ' ' . $class);
 }
 
 $object = $class::byId(init('id'));
 if (!is_object($object)) {
-  throw new Exception(__('L\'objet n\'existe pas :', __FILE__) . ' ' . init('id'));
+  throw new Exception(new Trad('L\'objet n\'existe pas :', __FILE__) . ' ' . init('id'));
 }
 
 $array = utils::o2a($object);
 if (count($array) == 0) {
-  throw new Exception(__('L\'objet n\'a aucun élément :', __FILE__) . ' ' . print_r($array, true));
+  throw new Exception(new Trad('L\'objet n\'a aucun élément :', __FILE__) . ' ' . print_r($array, true));
 }
 $otherInfo = array();
 if (method_exists($object, 'getCache') && !isset($array['cache'])) {
@@ -44,7 +44,7 @@ if ($class == 'cron' && $array['class'] == 'scenario' && $array['function'] == '
   $scenario = scenario::byId($array['option']['scenario_id']);
   $scenarioElement = scenarioElement::byId($array['option']['scenarioElement_id']);
   if (is_object($scenarioElement) && is_object($scenario)) {
-    $otherInfo['doIn'] = __('Scénario :', __FILE__) . ' ' . $scenario->getName() . "\n" . str_replace(array('"'), array("'"), $scenarioElement->export());
+    $otherInfo['doIn'] = new Trad('Scénario :', __FILE__) . ' ' . $scenario->getName() . "\n" . str_replace(array('"'), array("'"), $scenarioElement->export());
   }
 }
 if ($class == 'eqLogic') {

--- a/desktop/modal/report.bug.php
+++ b/desktop/modal/report.bug.php
@@ -32,7 +32,7 @@ foreach ($healths as $health) {
   }
   if ($first) {
     echo '<div class="alert alert-danger">';
-    echo __('Attention nous avons detecté les soucis suivant :', __FILE__) . ' ' . '<br/>';
+    echo new Trad('Attention nous avons detecté les soucis suivant :', __FILE__) . ' ' . '<br/>';
   }
   $first = false;
   echo '- ' . $health['name'] . '  : ' . $health['result'];

--- a/desktop/modal/scenario.jsonEdit.php
+++ b/desktop/modal/scenario.jsonEdit.php
@@ -20,7 +20,7 @@ if (!isConnect()) {
 }
 $scenario = scenario::byId(init('id'));
 if (!is_object($scenario)) {
-  throw new Exception(__('Aucun scénario ne correspondant à :', __FILE__) . ' ' . init('id'));
+  throw new Exception(new Trad('Aucun scénario ne correspondant à :', __FILE__) . ' ' . init('id'));
 }
 sendVarToJs('jeephp2js.md_scenarioJsonEdit_scId', init('id'));
 include_file('3rdparty', 'codemirror/addon/selection/active-line', 'js');

--- a/desktop/modal/scenario.log.execution.php
+++ b/desktop/modal/scenario.log.execution.php
@@ -20,7 +20,7 @@ if (!isConnect()) {
 }
 $scenario = scenario::byId(init('scenario_id'));
 if (!is_object($scenario)) {
-  throw new Exception(__('Aucun scénario ne correspondant à :', __FILE__) . ' ' . init('scenario_id'));
+  throw new Exception(new Trad('Aucun scénario ne correspondant à :', __FILE__) . ' ' . init('scenario_id'));
 }
 sendVarToJs('jeephp2js.md_scenarioLog_scId', init('scenario_id'));
 ?>

--- a/desktop/modal/summary.action.php
+++ b/desktop/modal/summary.action.php
@@ -24,7 +24,7 @@ if (init('object_id') == '') {
   $virtual = eqLogic::byLogicalId('summary' . init('object_id'), 'virtual');
 }
 if (!is_object($virtual)) {
-  throw new Exception(__('L\'objet n\'existe pas :', __FILE__) . ' ' . init('object_id'));
+  throw new Exception(new Trad('L\'objet n\'existe pas :', __FILE__) . ' ' . init('object_id'));
 }
 $removeCmd = array();
 foreach ($virtual->getCmd() as $cmd) {

--- a/desktop/modal/update.display.php
+++ b/desktop/modal/update.display.php
@@ -20,7 +20,7 @@ if (!isConnect('admin')) {
 }
 $repo = update::repoById(init('repo', 'market'));
 if ($repo['enable'] == 0) {
-  throw new Exception(__('Le dépôt est inactif :', __FILE__) . ' ' . init('repo', 'market'));
+  throw new Exception(new Trad('Le dépôt est inactif :', __FILE__) . ' ' . init('repo', 'market'));
 }
 include_file('core', init('repo', 'market') . '.display', 'repo');
 ?>

--- a/desktop/modal/update.list.php
+++ b/desktop/modal/update.list.php
@@ -20,7 +20,7 @@ if (!isConnect('admin')) {
 }
 $repo = update::repoById(init('repo', 'market'));
 if ($repo['enable'] == 0) {
-  throw new Exception(__('Le dépôt est inactif :', __FILE__) . ' ' . init('repo'));
+  throw new Exception(new Trad('Le dépôt est inactif :', __FILE__) . ' ' . init('repo'));
 }
 include_file('core', init('repo', 'market') . '.list', 'repo');
 ?>

--- a/desktop/modal/update.send.php
+++ b/desktop/modal/update.send.php
@@ -20,7 +20,7 @@ if (!isConnect('admin')) {
 }
 $repo = update::repoById(init('repo', 'market'));
 if ($repo['enable'] == 0) {
-  throw new Exception(__('Le dépôt est inactif :', __FILE__) . ' ' . init('repo'));
+  throw new Exception(new Trad('Le dépôt est inactif :', __FILE__) . ' ' . init('repo'));
 }
 include_file('core', init('repo', 'market') . '.send', 'repo');
 ?>

--- a/desktop/modal/user.rights.php
+++ b/desktop/modal/user.rights.php
@@ -21,7 +21,7 @@ if (!isConnect('admin')) {
 $user = user::byId(init('id'));
 
 if (!is_object($user)) {
-  throw new Exception(__('Impossible de trouver l\'utilisateur :', __FILE__) . ' ' . init('id'));
+  throw new Exception(new Trad('Impossible de trouver l\'utilisateur :', __FILE__) . ' ' . init('id'));
 }
 sendVarToJs('jeephp2js.md_userRights_rights', utils::o2a($user));
 ?>
@@ -265,17 +265,17 @@ sendVarToJs('jeephp2js.md_userRights_rights', utils::o2a($user));
         <tbody>
         <?php
           $menus = array(
-            'overview' => __('Synthèse',__FILE__),
-            'dashboard' => __('Dashboard',__FILE__),
-            'view' => __('Vue',__FILE__),
-            'plan' => __('Design',__FILE__),
-            'plan3d' => __('Design 3D',__FILE__),
-            'analyze' => __('[Globale] Analyse',__FILE__),
-            'timeline' => __('Timeline',__FILE__),
-            'history' => __('Historique',__FILE__),
-            'settings' => __('[Globale] Réglages',__FILE__),
-            'profils' => __('Préférences',__FILE__),
-            'mobile' => __('Version mobile',__FILE__),
+            'overview' => new Trad('Synthèse', __FILE__),
+            'dashboard' => new Trad('Dashboard', __FILE__),
+            'view' => new Trad('Vue', __FILE__),
+            'plan' => new Trad('Design', __FILE__),
+            'plan3d' => new Trad('Design 3D', __FILE__),
+            'analyze' => new Trad('[Globale] Analyse', __FILE__),
+            'timeline' => new Trad('Timeline', __FILE__),
+            'history' => new Trad('Historique', __FILE__),
+            'settings' => new Trad('[Globale] Réglages', __FILE__),
+            'profils' => new Trad('Préférences', __FILE__),
+            'mobile' => new Trad('Version mobile', __FILE__),
           );
           $html = '';
           foreach ($menus as $key => $value) {

--- a/desktop/php/dashboard.php
+++ b/desktop/php/dashboard.php
@@ -1,6 +1,6 @@
 <?php
 if (!isConnect()) {
-	throw new Exception(__('401 - Accès non autorisé', __FILE__));
+	throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 }
 //DisplayByObject or display by summaries:
 $DisplayByObject = true;

--- a/desktop/php/display.php
+++ b/desktop/php/display.php
@@ -89,7 +89,7 @@ function jeedom_displayObjectGroup($object = -1) {
 		$translate_category = '';
 		foreach ($JEEDOM_INTERNAL_CONFIG['eqLogic']['category'] as $key => $value) {
 			if ($eqLogic->getCategory($key, 0) == 1) {
-				$translate_category .= __($value['name'], __FILE__) . ',';
+				$translate_category .= new Trad($value['name'], __FILE__) . ',';
 			}
 		}
 		$translate_category = trim($translate_category, ',');

--- a/desktop/php/history.php
+++ b/desktop/php/history.php
@@ -113,7 +113,7 @@ $date = array(
 							$_echo .= '<span class="label cursor displayObject labelObjectHuman" data-object_id="o' . $eqLogic->getObject_id() . '">' . $object->getName() . ' <i class="fas fa-arrow-circle-right"></i></span>';
 						}
 					} else {
-						$_echo .= '<span class="label label-default cursor displayObject" data-object_id="o' . $eqLogic->getObject_id() . '>' . __('Aucun', __FILE__) . ' <i class="fas fa-arrow-circle-right"></i></span>';
+						$_echo .= '<span class="label label-default cursor displayObject" data-object_id="o' . $eqLogic->getObject_id() . '>' . new Trad('Aucun', __FILE__) . ' <i class="fas fa-arrow-circle-right"></i></span>';
 					}
 					$_echo .= '<br/>';
 					$_echo .= '<div class="cmdList" data-object_id="o' . $eqLogic->getObject_id() . '" style="display:none;margin-left : 20px;">';

--- a/desktop/php/interact.php
+++ b/desktop/php/interact.php
@@ -6,7 +6,7 @@ if (!isConnect('admin')) {
 global $interacts;
 $interacts = array();
 $totalInteract = interactDef::all();
-$interacts[__('Aucun', __FILE__)] = interactDef::all(null);
+$interacts[new Trad('Aucun', __FILE__)] = interactDef::all(null);
 $interactListGroup = interactDef::listGroup();
 if (is_array($interactListGroup)) {
 	foreach ($interactListGroup as $group) {
@@ -20,7 +20,7 @@ function jeedom_displayInteractGroup($_group = '', $_index = -1) {
 	$thisDiv = '';
 
 	if ($_group == '') {
-		$groupName = __('Aucun', __FILE__);
+		$groupName = new Trad('Aucun', __FILE__);
 		$href = '#config_none';
 		$id = 'config_none';
 	} else {
@@ -106,7 +106,7 @@ function jeedom_displayInteractGroup($_group = '', $_index = -1) {
 
 			$div .= '<div class="panel-group" id="accordionInteract">';
 			//No group first:
-			if (isset($interacts[__('Aucun', __FILE__)]) && count($interacts[__('Aucun', __FILE__)]) > 0) {
+			if (isset($interacts[new Trad('Aucun', __FILE__)]) && count($interacts[new Trad('Aucun', __FILE__)]) > 0) {
 				$div .= jeedom_displayInteractGroup();
 			}
 			echo $div;

--- a/desktop/php/reboot.php
+++ b/desktop/php/reboot.php
@@ -1,6 +1,6 @@
 <?php
 if (!isConnect('admin')) {
-	throw new Exception(__('401 - Accès non autorisé', __FILE__));
+	throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 }
 ?>
 

--- a/desktop/php/shutdown.php
+++ b/desktop/php/shutdown.php
@@ -1,6 +1,6 @@
 <?php
 if (!isConnect('admin')) {
-	throw new Exception(__('401 - Accès non autorisé', __FILE__));
+	throw new Exception(new Trad('401 - Accès non autorisé', __FILE__));
 }
 ?>
 

--- a/docs/fr_FR/static-analysis/phpstan.md
+++ b/docs/fr_FR/static-analysis/phpstan.md
@@ -2,12 +2,7 @@
 
 ## Installation locale
 
-1. Télécharger PHPStan :
-```bash
-wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-```
-
-2. Mettre à jour les dépendances :
+1. Mettre à jour les dépendances :
 ```bash
 composer update --ignore-platform-reqs
 ```
@@ -43,7 +38,7 @@ Notes importantes :
 
 ### Lancer l'analyse
 ```bash
-php phpstan.phar analyse --configuration phpstan.neon
+vendor/bin/phpstan analyse --configuration phpstan.neon
 ```
 
 ### Types d'erreurs courantes et solutions

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: core/ajax/report.ajax.php
 
 		-
-			message: '#^Variable \$cmd might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: core/ajax/scenario.ajax.php
-
-		-
 			message: '#^Variable \$converts might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,18 +301,6 @@ parameters:
 			path: core/class/scenarioExpression.class.php
 
 		-
-			message: '#^Undefined variable\: \$_parameters$#'
-			identifier: variable.undefined
-			count: 8
-			path: core/class/scenarioExpression.class.php
-
-		-
-			message: '#^Variable \$_parameters in isset\(\) is never defined\.$#'
-			identifier: isset.variable
-			count: 4
-			path: core/class/scenarioExpression.class.php
-
-		-
 			message: '#^Static method update\:\:getLastAvailableVersion\(\) invoked with 1 parameter, 0 required\.$#'
 			identifier: arguments.count
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -175,24 +175,6 @@ parameters:
 			path: core/class/cmd.class.php
 
 		-
-			message: '#^Static method event\:\:add\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 2
-			path: core/class/config.class.php
-
-		-
-			message: '#^Static method event\:\:add\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: core/class/eqLogic.class.php
-
-		-
-			message: '#^Static method event\:\:add\(\) invoked with 3 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: core/class/event.class.php
-
-		-
 			message: '#^Variable \$goupingType might not be defined\.$#'
 			identifier: variable.undefined
 			count: 3
@@ -259,12 +241,6 @@ parameters:
 			path: core/class/jsonrpcClient.class.php
 
 		-
-			message: '#^Static method event\:\:add\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: core/class/message.class.php
-
-		-
 			message: '#^Instantiated class openvpn not found\.$#'
 			identifier: class.notFound
 			count: 1
@@ -277,12 +253,6 @@ parameters:
 			path: core/class/plugin.class.php
 
 		-
-			message: '#^Static method event\:\:add\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 2
-			path: core/class/scenario.class.php
-
-		-
 			message: '#^Variable \$return might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -292,12 +262,6 @@ parameters:
 			message: '#^Instantiated class SolarData\\SolarData not found\.$#'
 			identifier: class.notFound
 			count: 1
-			path: core/class/scenarioExpression.class.php
-
-		-
-			message: '#^Static method event\:\:add\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
-			count: 6
 			path: core/class/scenarioExpression.class.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -97,12 +97,6 @@ parameters:
 			path: core/api/jeeApi.php
 
 		-
-			message: '#^Static method log\:\:getDelta\(\) invoked with 8 parameters, 0\-7 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: core/api/jeeApi.php
-
-		-
 			message: '#^Variable \$cmd might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -166,12 +160,6 @@ parameters:
 			message: '#^Static method jeedom\:\:update\(\) invoked with 2 parameters, 0\-1 required\.$#'
 			identifier: arguments.count
 			count: 2
-			path: core/api/proApi.php
-
-		-
-			message: '#^Static method log\:\:getDelta\(\) invoked with 8 parameters, 0\-7 required\.$#'
-			identifier: arguments.count
-			count: 1
 			path: core/api/proApi.php
 
 		-

--- a/tests/class/cmdTest.php
+++ b/tests/class/cmdTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+use PHPUnit\Framework\TestCase;
+
+class cmdTest extends TestCase
+{
+    public function testFormatValueNumericRoundWithNonNumericCalculResult()
+    {
+        $cmd = new cmd();
+        $cmd->setType('info');
+        $cmd->setSubType('numeric');
+        $cmd->setConfiguration('historizeRound', 1);
+        $cmd->setConfiguration('calculValueOffset', '#value# * 2 ~ \'mm\'');
+
+        $actualResult = $cmd->formatValue('1,2');
+
+        self::assertSame(2.4, $actualResult);
+    }
+}


### PR DESCRIPTION
Hello @kwizer15 
Je fais suite à cette discussion sur une PR du core https://github.com/jeedom/core/pull/2910 

Mon but était initialement d'utiliser l'autoloader de composer, et de là j'ai ajouté le chargement automatique des fichiers de configuration. Mais j'ai eu le problème avec `core/config/jeedom.config.php` qui invoque la traduction au travers de __() et donc la db pour avoir la configuration. Donc évidemment problème pour PHPStan.

J'ai fait sans ce fichier dans la PR initiale mais j'ai essayé de le corriger de mon côté. Pour cela j'ai remplacé cette fonction par un objet [Trad](https://github.com/pifou25/jeedom-core/commit/9924f80f7130babd53aec56b801c1a5b40a9db50#diff-142a72f37e8e40ade7dafa2ab05b6137a15d062bef985db4035e9217fdcc6f3a) mais ça n'a pas marché non plus. Il semble que PHPStan introspecte l'objet et donc invoque le __toString() dès le chargement.
_Pourtant j'ai testé Trad en ligne ici https://onlinephp.io/c/f7229 et ça fait bien ce que je veux._

J'ai donc été obligé d'ajouter une condition dans le code pour sauter cette valeur lors des test avec une constante `PHPSTAN_RUNNING` déclarée dans le bootstrap du PhpStan
```
        if (defined('PHPSTAN_RUNNING')) {
            return '__PHPSTAN_PLACEHOLDER__';
        }
```

C'est lourd et au final ça ne me convient pas. En plus, remplacer la fonction __() par `new Trad()` c'était assez lourd ça touche +100 fichiers.
Du coup je te soumet la PR sur ton fork pour continuer l'étude :) Tu pense que ça marcherait mieux avec l'interface ArrayAccess ?

PS: en plus sur le upstream ça fait 1 an qu'ils ne mergent plus rien en attente du passage en stable je suppose, on ferait aussi bien de préparer la next 4.6 de notre coté!