### PR TITLE
Corriger la XSS dans sendVarToJS

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -158,9 +158,9 @@ function sendVarToJS($_varName, $_value = '') {
 	$jsVar = '<script>';
 	foreach ($_varName as $name => $value) {
 		if (is_array($value) || is_object($value)) {
-			// Double json_encode : l'inner sérialise la donnée, l'outer encode le JSON en string literal JS
-			// pour le passer à JSON.parse(). JSON.parse préserve __proto__ comme own property
-			// (un object literal l'assignerait au prototype — prototype pollution).
+			// Double json_encode: the inner call serializes the data, the outer wraps the JSON
+			// into a JS string literal passed to JSON.parse(). JSON.parse preserves __proto__
+			// as an own property (an object literal would assign it to the prototype — prototype pollution).
 			$encoded = 'JSON.parse(' . json_encode(json_encode($value, $flags), $flags) . ')';
 		} else {
 			$encoded = json_encode((string) $value, $flags);

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -154,13 +154,21 @@ function sendVarToJS($_varName, $_value = '') {
 	if (!is_array($_varName)) {
 		$_varName = [$_varName => $_value];
 	}
+	$flags = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE;
 	$jsVar = '<script>';
 	foreach ($_varName as $name => $value) {
-		$value = (is_array($value)) ? 'JSON.parse("' . addslashes(json_encode($value, JSON_UNESCAPED_UNICODE)) . '")'	: '"' . $value . '"';
-		if (strpos($name, '.') === false) {
-			$jsVar .= 'var ' . $name . ' = ' . $value . "\n";
+		if (is_array($value) || is_object($value)) {
+			// Double json_encode : l'inner sérialise la donnée, l'outer encode le JSON en string literal JS
+			// pour le passer à JSON.parse(). JSON.parse préserve __proto__ comme own property
+			// (un object literal l'assignerait au prototype — prototype pollution).
+			$encoded = 'JSON.parse(' . json_encode(json_encode($value, $flags), $flags) . ')';
 		} else {
-			$jsVar .= $name . ' = ' . $value . "\n";
+			$encoded = json_encode((string) $value, $flags);
+		}
+		if (strpos($name, '.') === false) {
+			$jsVar .= 'var ' . $name . ' = ' . $encoded . "\n";
+		} else {
+			$jsVar .= $name . ' = ' . $encoded . "\n";
 		}
 	}
 	$jsVar .= '</script>';

--- a/tests/php/utilsTest.php
+++ b/tests/php/utilsTest.php
@@ -98,4 +98,71 @@ class utilsTest extends TestCase {
 	public function testCleanPath($in, $out) {
 		$this->assertSame($out, cleanPath($in));
 	}
+
+	private function captureSendVarToJS($name, $value) {
+		ob_start();
+		sendVarToJS($name, $value);
+		return ob_get_clean();
+	}
+
+	public function testSendVarToJSScalarEscapesClosingScriptTag() {
+		$out = $this->captureSendVarToJS('foo', '</script><script>alert(1)</script>');
+		$this->assertSame(1, substr_count($out, '<script>'), 'Only one opening <script> tag should be emitted');
+		$this->assertSame(1, substr_count($out, '</script>'), 'Only one closing </script> tag should be emitted');
+		$this->assertStringNotContainsString('</script><script>alert(1)', $out, 'Raw payload must not appear unescaped');
+	}
+
+	public function testSendVarToJSScalarEscapesQuote() {
+		$out = $this->captureSendVarToJS('foo', 'bar"; evil=1; //');
+		$this->assertStringNotContainsString('"; evil=1', $out, 'Quote must be escaped so the injected statement stays inside the JS string literal');
+	}
+
+	public function testSendVarToJSArrayValueEscapesClosingScriptTag() {
+		$out = $this->captureSendVarToJS('foo', ['x' => '</script><script>alert(1)</script>']);
+		$this->assertSame(1, substr_count($out, '<script>'), 'Only one opening <script> tag should be emitted');
+		$this->assertSame(1, substr_count($out, '</script>'), 'Only one closing </script> tag should be emitted');
+	}
+
+	public function testSendVarToJSArrayGoesThroughJsonParse() {
+		$out = $this->captureSendVarToJS('foo', ['__proto__' => ['polluted' => true]]);
+		$this->assertStringContainsString('JSON.parse(', $out, 'Arrays must be wrapped in JSON.parse to keep __proto__ as an own property (object literal would assign prototype)');
+	}
+
+	public function testSendVarToJSObjectGoesThroughJsonParse() {
+		$obj = new \stdClass();
+		$obj->foo = 'bar';
+		$out = $this->captureSendVarToJS('myObj', $obj);
+		$this->assertStringContainsString('JSON.parse(', $out, 'Objects must be wrapped in JSON.parse like arrays');
+		$this->assertStringContainsString('var myObj = JSON.parse(', $out);
+	}
+
+	public function testSendVarToJSDottedNameAssigns() {
+		$out = $this->captureSendVarToJS('jeephp2js.foo', 'bar');
+		$this->assertStringContainsString('jeephp2js.foo = "bar"', $out, 'Dotted names must be emitted without var');
+		$this->assertStringNotContainsString('var jeephp2js.foo', $out, 'var keyword would produce a syntax error on a dotted access');
+	}
+
+	public function getNonStringScalars() {
+		return array(
+			array(true, '"1"'),
+			array(false, '""'),
+			array(null, '""'),
+			array(0, '"0"'),
+			array(42, '"42"'),
+			array(3.14, '"3.14"'),
+		);
+	}
+
+	/**
+	* @dataProvider getNonStringScalars
+	*/
+	public function testSendVarToJSCastsNonStringScalarsToString($value, $expected) {
+		$out = $this->captureSendVarToJS('foo', $value);
+		$this->assertStringContainsString('var foo = ' . $expected, $out, 'Non-string scalars must be cast to string for backwards compatibility');
+	}
+
+	public function testSendVarToJSEscapesBackslash() {
+		$out = $this->captureSendVarToJS('foo', 'a\\b');
+		$this->assertStringContainsString('"a\\\\b"', $out, 'Backslash must be escaped so JS does not interpret \\b as backspace');
+	}
 }


### PR DESCRIPTION
La fonction émettait les valeurs scalaires entre guillemets sans échappement, et les valeurs de tableau via addslashes(json_encode()), qui n'échappe pas `<`. Une valeur contenant `</script>` ou un guillemet permettait de casser le contexte HTML/JS et d'injecter du code arbitraire.

Le rendu utilise maintenant json_encode avec JSON_HEX_TAG, JSON_HEX_AMP, JSON_HEX_APOS et JSON_HEX_QUOT, qui encodent `<`, `>`, `&`, `'` et `"` en séquences \uXXXX inoffensives dans tout contexte. Pour les tableaux et objets, le wrapper JSON.parse("...") est préservé : il garantit que `__proto__` reste une propriété propre au lieu d'être assignée au prototype (object literal) — ce qui aurait ouvert une prototype pollution. Les scalaires non-string sont castés en string pour préserver le comportement d'origine (compatibilité ascendante).

Tests dans tests/php/utilsTest.php couvrant :
- vecteurs scalaires (`</script>`, guillemet)
- vecteur tableau (`</script>` dans une valeur)
- présence du wrapper JSON.parse pour tableau et objet
- clé pointée émise sans `var`
- scalaires non-string (bool/int/null/float) castés en string
- backslash correctement échappé