### PR TITLE
Corriger le path traversal dans l'éditeur de fichiers

### DIFF
--- a/core/ajax/jeedom.ajax.php
+++ b/core/ajax/jeedom.ajax.php
@@ -474,12 +474,8 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$pathfile = calculPath(init('path'));
+		$pathfile = resolvePath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(ls($pathfile, '*', false, array(init('type'))));
@@ -494,12 +490,8 @@ try {
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
 			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
-		$pathfile = calculPath(init('path'));
+		$pathfile = resolvePath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(file_get_contents($pathfile));
@@ -514,12 +506,8 @@ try {
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
 			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
-		$pathfile = calculPath(init('path'));
+		$pathfile = resolvePath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(file_put_contents($pathfile, init('content')));
@@ -534,12 +522,8 @@ try {
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
 			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
-		$pathfile = calculPath(init('path'));
+		$pathfile = resolvePath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(unlink($pathfile));
@@ -554,16 +538,12 @@ try {
 		if (!in_array($pathinfo['extension'], array('php', 'js', 'json', 'sql', 'ini', 'css', 'py', 'css', 'html', 'yaml', 'config', 'conf'))) {
 			throw new Exception(__('Vous ne pouvez éditer ce type d\'extension :', __FILE__) . ' ' . $pathinfo['extension']);
 		}
-		$pathfile = calculPath(init('path'));
-		if ($pathfile === false) {
+		$target = resolvePath(rtrim(init('path'), '/') . '/' . init('name'));
+		if ($target === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		touch($pathfile . init('name'));
-		if (!file_exists($pathfile . init('name'))) {
+		touch($target);
+		if (!file_exists($target)) {
 			throw new Exception(__('Impossible de créer le fichier, vérifiez les droits', __FILE__));
 		}
 		ajax::success();
@@ -571,39 +551,28 @@ try {
 
 	if (init('action') == 'createFolder') {
 		unautorizedInDemo();
-		$pathfile = calculPath(init('path'));
-		if ($pathfile === false) {
+		$target = resolvePath(rtrim(init('path'), '/') . '/' . init('name'));
+		if ($target === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		mkdir($pathfile . '/' . init('name'));
+		mkdir($target);
 		ajax::success();
 	}
 
 	if (init('action') == 'renameFolder') {
 		unautorizedInDemo();
-		$pathfile = calculPath(init('src'));
-		if ($pathfile === false) {
+		$src = resolvePath(init('src'));
+		$dst = resolvePath(init('dst'));
+		if ($src === false || $dst === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		ajax::success(rename($pathfile, init('dst')));
+		ajax::success(rename($src, $dst));
 	}
 
 	if (init('action') == 'deleteFolder') {
 		unautorizedInDemo();
-		$pathfile = calculPath(init('path'));
+		$pathfile = resolvePath(init('path'));
 		if ($pathfile === false) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		$rootPath = realpath(__DIR__ . '/../../');
-		if (strpos($pathfile, $rootPath) === false) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		ajax::success(rrmdir($pathfile));

--- a/core/php/downloadFile.php
+++ b/core/php/downloadFile.php
@@ -35,13 +35,16 @@ try {
 	}
 
 	unautorizedInDemo();
-	$pathfile = calculPath(init('pathfile'));
-	$pathfile = (strpos($pathfile, '*') !== false) ? realpath(str_replace('*', '', $pathfile)) . '/*' : realpath($pathfile);
+	$rawPath = init('pathfile');
+	$hasWildcard = (strpos($rawPath, '*') !== false);
+	$cleanPath = $hasWildcard ? str_replace('*', '', $rawPath) : $rawPath;
+	$resolved = resolvePath($cleanPath);
 
-	if ($pathfile === false) {
+	if ($resolved === false) {
 		log::add('api', 'debug', 'downloadFile - fichier introuvable');
 		throw new Exception(__('401 - Accès non autorisé', __FILE__));
 	}
+	$pathfile = $hasWildcard ? rtrim($resolved, '/') . '/*' : $resolved;
 
 	if (!$isAdmin) {
 		$authorized = false;

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1006,11 +1006,49 @@ function br2nl($string) {
 	return preg_replace('/\<br(\s*)?\/?\>/i', "\n", $string);
 }
 
-function calculPath($_path) {
+function resolvePath($_path) {
+	$rootPath = realpath(__DIR__ . '/../../');
+	if ($rootPath === false) {
+		return false;
+	}
+	$candidate = (strpos($_path, '/') === 0) ? $_path : $rootPath . '/' . $_path;
+	$real = realpath($candidate);
+	if ($real === false) {
+		// Le fichier peut ne pas exister (cas création) : valider le dossier parent.
+		$parent = realpath(dirname($candidate));
+		if ($parent === false) {
+			return false;
+		}
+		$real = $parent . DIRECTORY_SEPARATOR . basename($candidate);
+	}
+	if ($real !== $rootPath && strpos($real, $rootPath . DIRECTORY_SEPARATOR) !== 0) {
+		return false;
+	}
+	return $real;
+}
+
+function resolvePathUnsafe($_path) {
 	if (strpos($_path, '/') !== 0) {
 		return __DIR__ . '/../../' . $_path;
 	}
 	return $_path;
+}
+
+function calculPath($_path, $_allowOutsideRoot = false) {
+	if ($_allowOutsideRoot) {
+		return resolvePathUnsafe($_path);
+	}
+	$under = resolvePath($_path);
+	if ($under !== false) {
+		return $under;
+	}
+	trigger_error(
+		'calculPath() avec un chemin hors webroot est déprécié. '
+		. 'Utilisez resolvePathUnsafe() pour conserver ce comportement, '
+		. 'ou passez true en 2e argument.',
+		E_USER_DEPRECATED
+	);
+	return resolvePathUnsafe($_path);
 }
 
 function getDirectorySize($path) {

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1006,6 +1006,12 @@ function br2nl($string) {
 	return preg_replace('/\<br(\s*)?\/?\>/i', "\n", $string);
 }
 
+/**
+ * Resolve a path under the Jeedom webroot, rejecting anything that escapes it.
+ *
+ * @param string $_path Absolute path or path relative to the webroot.
+ * @return string|false Canonical absolute path under the webroot, or false if outside or unresolvable.
+ */
 function resolvePath($_path) {
 	$rootPath = realpath(__DIR__ . '/../../');
 	if ($rootPath === false) {
@@ -1014,7 +1020,7 @@ function resolvePath($_path) {
 	$candidate = (strpos($_path, '/') === 0) ? $_path : $rootPath . '/' . $_path;
 	$real = realpath($candidate);
 	if ($real === false) {
-		// Le fichier peut ne pas exister (cas création) : valider le dossier parent.
+		// Target file may not exist yet (creation case): validate the parent directory instead.
 		$parent = realpath(dirname($candidate));
 		if ($parent === false) {
 			return false;
@@ -1027,6 +1033,13 @@ function resolvePath($_path) {
 	return $real;
 }
 
+/**
+ * Legacy path resolver that accepts paths outside the webroot (no realpath, no sandbox check).
+ *
+ * @param string $_path Absolute path or path relative to the webroot.
+ * @return string Resolved path (absolute if prefixed with /, otherwise prefixed with the webroot).
+ * @see resolvePath() For the sandboxed variant.
+ */
 function resolvePathUnsafe($_path) {
 	if (strpos($_path, '/') !== 0) {
 		return __DIR__ . '/../../' . $_path;
@@ -1034,6 +1047,16 @@ function resolvePathUnsafe($_path) {
 	return $_path;
 }
 
+/**
+ * Resolve a path inside the webroot, falling back to the unsafe resolver when $_allowOutsideRoot is true.
+ * Triggers E_USER_DEPRECATED when the fallback is hit implicitly (legacy callers).
+ *
+ * @param string $_path             Absolute path or path relative to the webroot.
+ * @param bool   $_allowOutsideRoot When true, bypass sandboxing and return the unsafe resolution.
+ * @return string|false Resolved path under the webroot, the unsafe resolution, or false when sandboxed and unresolvable.
+ * @see resolvePath()
+ * @see resolvePathUnsafe()
+ */
 function calculPath($_path, $_allowOutsideRoot = false) {
 	if ($_allowOutsideRoot) {
 		return resolvePathUnsafe($_path);
@@ -1043,9 +1066,9 @@ function calculPath($_path, $_allowOutsideRoot = false) {
 		return $under;
 	}
 	trigger_error(
-		'calculPath() avec un chemin hors webroot est déprécié. '
-		. 'Utilisez resolvePathUnsafe() pour conserver ce comportement, '
-		. 'ou passez true en 2e argument.',
+		'calculPath() with a path outside the webroot is deprecated. '
+		. 'Use resolvePathUnsafe() to keep this behaviour, '
+		. 'or pass true as the second argument.',
 		E_USER_DEPRECATED
 	);
 	return resolvePathUnsafe($_path);

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -391,7 +391,7 @@ class repo_market {
 		if (config::byKey('market::cloud::backup::password') != config::byKey('market::cloud::backup::password_confirmation')) {
 			throw new Exception(__('Le mot de passe du backup cloud n\'est pas identique à la confirmation', __FILE__));
 		}
-		$backup_dir = calculPath(config::byKey('backup::path'));
+		$backup_dir = resolvePathUnsafe(config::byKey('backup::path'));
 		if (!file_exists($backup_dir)) {
 			mkdir($backup_dir, 0770, true);
 		}

--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -206,7 +206,7 @@ class repo_samba {
 	}
 
 	public static function backup_restore($_backup) {
-		$backup_dir = calculPath(config::byKey('backup::path'));
+		$backup_dir = resolvePathUnsafe(config::byKey('backup::path'));
 		$cmd = 'cd ' . $backup_dir . ';';
 		$cmd .= self::makeSambaCommand('cd ' . config::byKey('samba::backup::folder') . ';get ' . $_backup);
 		com_shell::execute($cmd);

--- a/install/backup.php
+++ b/install/backup.php
@@ -46,7 +46,7 @@ try {
 
 	global $CONFIG;
 	$jeedom_dir = realpath(__DIR__ . '/..');
-	$backup_dir = calculPath(config::byKey('backup::path'));
+	$backup_dir = resolvePathUnsafe(config::byKey('backup::path'));
 	if (!file_exists($backup_dir)) {
 		mkdir($backup_dir, 0770, true);
 	}

--- a/tests/php/utilsTest.php
+++ b/tests/php/utilsTest.php
@@ -98,4 +98,87 @@ class utilsTest extends TestCase {
 	public function testCleanPath($in, $out) {
 		$this->assertSame($out, cleanPath($in));
 	}
+
+	private function rootPath() {
+		return realpath(__DIR__ . '/../../');
+	}
+
+	public function testResolvePathReturnsAbsoluteForRelativeUnderRoot() {
+		$result = resolvePath('core/php/utils.inc.php');
+		$this->assertSame($this->rootPath() . '/core/php/utils.inc.php', $result);
+	}
+
+	public function testResolvePathResolvesDotDotThatStaysUnderRoot() {
+		$result = resolvePath('core/php/../class');
+		$this->assertSame($this->rootPath() . '/core/class', $result);
+	}
+
+	public function testResolvePathRejectsAbsoluteOutsideRoot() {
+		$this->assertFalse(resolvePath('/etc/passwd'));
+	}
+
+	public function testResolvePathRejectsTraversalOutsideRoot() {
+		$this->assertFalse(resolvePath('../../../../../../etc/passwd'));
+	}
+
+	public function testResolvePathAcceptsCreationCandidateUnderRoot() {
+		$result = resolvePath('core/php/__nonexistent_test_file__.php');
+		$this->assertSame($this->rootPath() . '/core/php/__nonexistent_test_file__.php', $result);
+	}
+
+	public function testResolvePathRejectsCreationCandidateOutsideRoot() {
+		$this->assertFalse(resolvePath('/tmp/__nonexistent_test_file__.php'));
+	}
+
+	public function testResolvePathUnsafeReturnsAbsoluteAsIs() {
+		$this->assertSame('/etc/passwd', resolvePathUnsafe('/etc/passwd'));
+	}
+
+	public function testResolvePathUnsafePrefixesRelative() {
+		$result = resolvePathUnsafe('foo.txt');
+		$this->assertStringEndsWith('/foo.txt', $result);
+	}
+
+	public function testCalculPathLegitimateUnderRootDoesNotTriggerDeprecation() {
+		$errors = [];
+		set_error_handler(function ($errno, $errstr) use (&$errors) {
+			$errors[] = [$errno, $errstr];
+		}, E_USER_DEPRECATED);
+		try {
+			$result = calculPath('core/php/utils.inc.php');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame($this->rootPath() . '/core/php/utils.inc.php', $result);
+		$this->assertSame([], $errors, 'No deprecation should be raised when path resolves under the webroot');
+	}
+
+	public function testCalculPathOutsideRootTriggersDeprecation() {
+		$errors = [];
+		set_error_handler(function ($errno, $errstr) use (&$errors) {
+			$errors[] = [$errno, $errstr];
+		}, E_USER_DEPRECATED);
+		try {
+			$result = calculPath('/etc/passwd');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame('/etc/passwd', $result, 'Backward-compatible fallback returns the unsafe resolution');
+		$this->assertCount(1, $errors, 'A deprecation notice must be emitted');
+		$this->assertSame(E_USER_DEPRECATED, $errors[0][0]);
+	}
+
+	public function testCalculPathOutsideRootWithFlagDoesNotTriggerDeprecation() {
+		$errors = [];
+		set_error_handler(function ($errno, $errstr) use (&$errors) {
+			$errors[] = [$errno, $errstr];
+		}, E_USER_DEPRECATED);
+		try {
+			$result = calculPath('/etc/passwd', true);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame('/etc/passwd', $result);
+		$this->assertSame([], $errors, 'Explicit opt-in must silence the deprecation');
+	}
 }


### PR DESCRIPTION
calculPath() ne normalisait pas les `..`, et la validation dans les actions AJAX utilisait `strpos($pathfile, $rootPath) === false` qui match n'importe où dans la chaîne et n'applique aucun realpath. Un admin (ou attaquant ayant un cookie admin) pouvait ainsi lire, écrire, supprimer et créer des fichiers arbitraires sur tout le filesystem accessible au serveur via les actions getFileFolder, getFileContent, setFileContent, deleteFile, createFile, createFolder, renameFolder, deleteFolder de jeedom.ajax.php, et via downloadFile.php.

Architecture du fix :
- resolvePath() : nouvelle fonction sécurisée. Résout via realpath (gère .. et symlinks), accepte les fichiers à créer en validant le parent, retourne false si le résultat sort du webroot.
- resolvePathUnsafe() : nouvelle fonction explicite pour les cas légitimes où l'admin configure un chemin absolu hors webroot (config backup::path).
- calculPath($_path, $_allowOutsideRoot = false) : conserve la signature publique pour la compat plugins. Sans flag, tente d'abord resolvePath ; si ça échoue (chemin hors webroot), émet un E_USER_DEPRECATED et fallback sur resolvePathUnsafe pour ne casser aucun usage existant. Avec flag true, délègue directement à resolvePathUnsafe sans warning.

Migration des 13 appelants core :
- jeedom.ajax.php (×8) : resolvePath + bloquer si false. Les actions createFile/createFolder valident maintenant le chemin final (path + name), pas seulement le dossier parent — auparavant init('name') = '../etc/passwd' permettait un bypass. renameFolder valide aussi init('dst') qui ne l'était pas du tout.
- downloadFile.php : resolvePath + bloquer si false. Fix du même vecteur côté téléchargement (et nettoyage de la double appel à realpath).
- install/backup.php, market.repo.php, samba.repo.php : migration explicite vers resolvePathUnsafe (config admin légitime).

Tests dans tests/php/utilsTest.php couvrant chaque fonction (11 nouveaux cas) : chemins relatifs sous root, traversal, chemins absolus, fichiers à créer, et émission/silence de la deprecation.