### PR TITLE
Échapper les arguments shell des téléchargements et threads

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1385,11 +1385,11 @@ class jeedom {
 	/***************************************THREAD MANGEMENT**********************************************/
 
 	public static function checkOngoingThread($_cmd) {
-		return shell_exec('(ps ax || ps w) | grep "' . $_cmd . '$" | grep -v "grep" | wc -l');
+		return shell_exec(shellCheckOngoingThreadCommand($_cmd));
 	}
 
 	public static function retrievePidThread($_cmd) {
-		return shell_exec('(ps ax || ps w) | grep "' . $_cmd . '$" | grep -v "grep" | awk \'{print $1}\'');
+		return shell_exec(shellRetrievePidThreadCommand($_cmd));
 	}
 
 	/******************************************UTILS******************************************************/
@@ -1719,7 +1719,7 @@ class jeedom {
 		if (config::byKey('disable_ntp', 'core', 0) == 1) {
 			return;
 		}
-		shell_exec(system::getCmdSudo() . 'service ntp stop;' . system::getCmdSudo() . 'ntpdate -s ' . config::byKey('ntp::optionalServer', 'core', '0.debian.pool.ntp.org') . ';' . system::getCmdSudo() . 'service ntp start');
+		shell_exec(system::getCmdSudo() . 'service ntp stop;' . system::getCmdSudo() . 'ntpdate -s ' . escapeshellarg(config::byKey('ntp::optionalServer', 'core', '0.debian.pool.ntp.org')) . ';' . system::getCmdSudo() . 'service ntp start');
 	}
 
 	public static function cleanDatabase() {

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,31 @@ function calculPath($_path) {
 	return $_path;
 }
 
+function shellWgetCommand($_url, $_outputPath, $_logPath = null) {
+	$cmd = 'wget --no-check-certificate --progress=dot --dot=mega ' . escapeshellarg($_url) . ' -O ' . escapeshellarg($_outputPath);
+	if ($_logPath !== null) {
+		$cmd .= ' >> ' . escapeshellarg($_logPath) . ' 2>&1';
+	}
+	return $cmd;
+}
+
+function shellCurlCommand($_url, $_outputPath, $_token = null) {
+	$cmd = 'curl -s -L';
+	if ($_token !== null && $_token !== '') {
+		$cmd .= ' -H ' . escapeshellarg('Authorization: token ' . $_token);
+	}
+	$cmd .= ' ' . escapeshellarg($_url) . ' > ' . escapeshellarg($_outputPath);
+	return $cmd;
+}
+
+function shellCheckOngoingThreadCommand($_cmd) {
+	return '(ps ax || ps w) | grep ' . escapeshellarg($_cmd . '$') . ' | grep -v "grep" | wc -l';
+}
+
+function shellRetrievePidThreadCommand($_cmd) {
+	return '(ps ax || ps w) | grep ' . escapeshellarg($_cmd . '$') . ' | grep -v "grep" | awk \'{print $1}\'';
+}
+
 function getDirectorySize($path) {
 	$bytestotal = 0;
 	$path = realpath($path);

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,14 @@ function calculPath($_path) {
 	return $_path;
 }
 
+/**
+ * Build a shell-safe wget command to download a URL to a local path, optionally appending to a log file.
+ *
+ * @param string      $_url        URL to fetch.
+ * @param string      $_outputPath Destination file path.
+ * @param string|null $_logPath    Optional file to append stdout/stderr to.
+ * @return string Full shell command, ready for exec/shell_exec.
+ */
 function shellWgetCommand($_url, $_outputPath, $_logPath = null) {
 	$cmd = 'wget --no-check-certificate --progress=dot --dot=mega ' . escapeshellarg($_url) . ' -O ' . escapeshellarg($_outputPath);
 	if ($_logPath !== null) {
@@ -1021,6 +1029,14 @@ function shellWgetCommand($_url, $_outputPath, $_logPath = null) {
 	return $cmd;
 }
 
+/**
+ * Build a shell-safe curl command to download a URL to a local path, optionally with a bearer token.
+ *
+ * @param string      $_url        URL to fetch.
+ * @param string      $_outputPath Destination file path.
+ * @param string|null $_token      Optional bearer token for the `Authorization: token <token>` header.
+ * @return string Full shell command, ready for exec/shell_exec.
+ */
 function shellCurlCommand($_url, $_outputPath, $_token = null) {
 	$cmd = 'curl -s -L';
 	if ($_token !== null && $_token !== '') {
@@ -1030,10 +1046,22 @@ function shellCurlCommand($_url, $_outputPath, $_token = null) {
 	return $cmd;
 }
 
+/**
+ * Build a shell command that counts how many processes match a given command line.
+ *
+ * @param string $_cmd Process command line to match with a trailing-anchor regex.
+ * @return string Full shell pipeline that outputs the match count.
+ */
 function shellCheckOngoingThreadCommand($_cmd) {
 	return '(ps ax || ps w) | grep ' . escapeshellarg($_cmd . '$') . ' | grep -v "grep" | wc -l';
 }
 
+/**
+ * Build a shell command that returns the PIDs of processes matching a given command line.
+ *
+ * @param string $_cmd Process command line to match with a trailing-anchor regex.
+ * @return string Full shell pipeline that outputs one PID per line.
+ */
 function shellRetrievePidThreadCommand($_cmd) {
 	return '(ps ax || ps w) | grep ' . escapeshellarg($_cmd . '$') . ' | grep -v "grep" | awk \'{print $1}\'';
 }

--- a/core/repo/github.repo.php
+++ b/core/repo/github.repo.php
@@ -133,7 +133,7 @@ class repo_github {
 			unlink($tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
+			exec(system::getCmdSudo() . 'chmod 777 -R ' . escapeshellarg($tmp));
 		}
 		if (!is_writable($tmp_dir)) {
 			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
@@ -179,11 +179,7 @@ class repo_github {
 	public static function downloadCore($_path) {
 		$url = 'https://api.github.com/repos/' . config::byKey('github::core::user', 'core', 'jeedom') . '/' . config::byKey('github::core::repository', 'core', 'core') . '/zipball/' . config::byKey('github::core::branch', 'core', 'stable');
 		echo __('Téléchargement de', __FILE__) . ' ' . $url . '...';
-		if (config::byKey('github::token') == '') {
-			echo shell_exec('curl -s -L ' . $url . ' > ' . $_path);
-		} else {
-			echo shell_exec('curl -s -H "Authorization: token ' . config::byKey('github::token') . '" -L ' . $url . ' > ' . $_path);
-		}
+		echo shell_exec(shellCurlCommand($url, $_path, config::byKey('github::token')));
 		return;
 	}
 

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -975,7 +975,7 @@ class repo_market {
 		$url .= '&password_type=sha1';
 		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $this->getLogicalId() . '...');
 		log::add('update', 'alert', __('URL', __FILE__) . ' ' . $url);
-		exec('wget "' . $url . '" -O ' . $tmp . ' >> ' . log::getPathToLog('update') . ' 2>&1');
+		exec(shellWgetCommand($url, $tmp, log::getPathToLog('update')));
 		switch ($this->getType()) {
 			case 'plugin':
 				return $tmp;

--- a/core/repo/url.repo.php
+++ b/core/repo/url.repo.php
@@ -66,12 +66,12 @@ class repo_url {
 			unlink($tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
+			exec(system::getCmdSudo() . 'chmod 777 -R ' . escapeshellarg($tmp));
 		}
 		if (!is_writable($tmp_dir)) {
 			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
-		$result = exec('wget --no-check-certificate --progress=dot --dot=mega ' . $_update->getConfiguration('url') . ' -O ' . $tmp);
+		$result = exec(shellWgetCommand($_update->getConfiguration('url'), $tmp));
 		log::add('update', 'alert', $result);
 		return array('path' => $tmp, 'localVersion' => date('Y-m-d H:i:s'));
 	}

--- a/tests/php/utilsTest.php
+++ b/tests/php/utilsTest.php
@@ -98,4 +98,52 @@ class utilsTest extends TestCase {
 	public function testCleanPath($in, $out) {
 		$this->assertSame($out, cleanPath($in));
 	}
+
+	public function testShellWgetCommandEscapesUrl() {
+		$cmd = shellWgetCommand('https://example.com/foo; rm -rf /', '/tmp/out.zip');
+		$this->assertStringContainsString("'https://example.com/foo; rm -rf /'", $cmd);
+		$this->assertStringNotContainsString('https://example.com/foo; rm -rf / -O', $cmd);
+		$this->assertStringEndsWith("-O '/tmp/out.zip'", $cmd);
+	}
+
+	public function testShellWgetCommandEscapesOutputPath() {
+		$cmd = shellWgetCommand('https://example.com', '/tmp/$(rm -rf /).zip');
+		$this->assertStringContainsString("'/tmp/\$(rm -rf /).zip'", $cmd);
+	}
+
+	public function testShellWgetCommandWithLogPath() {
+		$cmd = shellWgetCommand('https://example.com', '/tmp/out', '/tmp/log; evil');
+		$this->assertStringContainsString("'/tmp/log; evil'", $cmd);
+		$this->assertStringEndsWith("2>&1", $cmd);
+	}
+
+	public function testShellCurlCommandWithoutToken() {
+		$cmd = shellCurlCommand('https://api.github.com/foo', '/tmp/out');
+		$this->assertStringNotContainsString('Authorization', $cmd);
+		$this->assertStringContainsString("'https://api.github.com/foo'", $cmd);
+		$this->assertStringContainsString("> '/tmp/out'", $cmd);
+	}
+
+	public function testShellCurlCommandWithToken() {
+		$cmd = shellCurlCommand('https://api', '/tmp/out', 'tk; evil');
+		$this->assertStringContainsString("'Authorization: token tk; evil'", $cmd);
+	}
+
+	public function testShellCurlCommandEscapesMaliciousUrl() {
+		$cmd = shellCurlCommand('https://api"; rm -rf /; "', '/tmp/out');
+		$this->assertStringNotContainsString('https://api"; rm -rf /; " ', $cmd);
+		$this->assertStringContainsString("'https://api\"; rm -rf /; \"'", $cmd);
+	}
+
+	public function testShellCheckOngoingThreadCommandEscapesCmd() {
+		$cmd = shellCheckOngoingThreadCommand('foo"; evil; "');
+		$this->assertStringContainsString("'foo\"; evil; \"\$'", $cmd);
+		$this->assertStringEndsWith('| wc -l', $cmd);
+	}
+
+	public function testShellRetrievePidThreadCommandEscapesCmd() {
+		$cmd = shellRetrievePidThreadCommand('foo"; evil; "');
+		$this->assertStringContainsString("'foo\"; evil; \"\$'", $cmd);
+		$this->assertStringEndsWith("awk '{print \$1}'", $cmd);
+	}
 }


### PR DESCRIPTION
Plusieurs sites construisaient des commandes shell par concaténation sans escapeshellarg, permettant à un admin compromis (ou attaquant ayant un cookie admin) de réaliser une RCE sur le serveur en configurant des URLs/serveurs de repo malicieux ou en injectant des caractères spéciaux dans des configurations.

4 helpers dans utils.inc.php pour centraliser l'échappement :
- shellWgetCommand($url, $output, $log = null)
- shellCurlCommand($url, $output, $token = null)
- shellCheckOngoingThreadCommand($cmd) — \"(ps ax || ps w) | grep ... | wc -l\"
- shellRetrievePidThreadCommand($cmd) — variante \"awk '{print \$1}'\"

Sites migrés (cités dans l'audit P1) :
- core/repo/url.repo.php : wget URL repo (concat brute) + chmod sur \$tmp
- core/repo/market.repo.php : wget URL avec guillemets manuels
- core/repo/github.repo.php : downloadCore (curl avec token) + chmod
- core/class/jeedom.class.php : checkOngoingThread, retrievePidThread (appelés depuis plugin.class.php avec une commande contenant l'id du plugin), et ntpdate sur ntp::optionalServer (config admin).

Tests dans tests/php/utilsTest.php (8 cas) avec payloads classiques (\`; rm -rf /\`, \`\$(...)\`, guillemets) vérifiant que la sortie contient l'argument entre quotes simples et pas la version brute.