### PR TITLE
Échapper les arguments shell de samba.repo.php

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,14 @@ function calculPath($_path) {
 	return $_path;
 }
 
+function shellSmbclientCommand($_share, $_userPassword, $_ip, $_innerCmd) {
+	return 'smbclient -t 120 '
+		. escapeshellarg($_share)
+		. ' -U ' . escapeshellarg($_userPassword)
+		. ' -I ' . escapeshellarg($_ip)
+		. ' -c ' . escapeshellarg($_innerCmd);
+}
+
 function getDirectorySize($path) {
 	$bytestotal = 0;
 	$path = realpath($path);

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,15 @@ function calculPath($_path) {
 	return $_path;
 }
 
+/**
+ * Build a shell-safe smbclient command with all arguments escaped.
+ *
+ * @param string $_share        Remote share path (e.g. //server/share).
+ * @param string $_userPassword Credential in the user%password form accepted by smbclient -U.
+ * @param string $_ip           Server IP address.
+ * @param string $_innerCmd     smbclient -c script (semicolon-separated commands).
+ * @return string Full smbclient command line, ready for exec/shell_exec.
+ */
 function shellSmbclientCommand($_share, $_userPassword, $_ip, $_innerCmd) {
 	return 'smbclient -t 120 '
 		. escapeshellarg($_share)

--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -106,16 +106,16 @@ class repo_samba {
 			unlink($tmp);
 		}
 		if (!is_writable($tmp_dir)) {
-			exec(system::getCmdSudo() . 'chmod 777 -R ' . $tmp);
+			exec(system::getCmdSudo() . 'chmod 777 -R ' . escapeshellarg($tmp));
 		}
 		if (!is_writable($tmp_dir)) {
 			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
-		$cmd = 'cd ' . $tmp_dir . ';';
+		$cmd = 'cd ' . escapeshellarg($tmp_dir) . ';';
 		$cmd .= self::makeSambaCommand('cd ' . config::byKey('samba::plugin::folder') . ';get ' . $_update->getConfiguration('path'), 'plugin');
 		com_shell::execute($cmd);
 		$pathinfo = pathinfo($_update->getConfiguration('path'));
-		com_shell::execute('mv ' . $tmp_dir . '/' . $pathinfo['basename'] . ' ' . $tmp);
+		com_shell::execute('mv ' . escapeshellarg($tmp_dir . '/' . $pathinfo['basename']) . ' ' . escapeshellarg($tmp));
 		$file = self::ls(config::byKey('samba::plugin::folder') . '/' . $_update->getConfiguration('path'), 'plugin');
 		if (count($file) != 1 || !isset($file[0]['datetime'])) {
 			return array('path' => $tmp, 'localVersion' => date('Y-m-d H:i:s'));
@@ -131,7 +131,12 @@ class repo_samba {
 	}
 
 	public static function makeSambaCommand($_cmd, $_type = 'backup') {
-		return system::getCmdSudo() . 'smbclient  -t 120 ' . config::byKey('samba::' . $_type . '::share') . ' -U "' . config::byKey('samba::' . $_type . '::username') . '%' . config::byKey('samba::' . $_type . '::password') . '" -I ' . config::byKey('samba::' . $_type . '::ip') . ' -c "' . $_cmd . '"';
+		return system::getCmdSudo() . shellSmbclientCommand(
+			config::byKey('samba::' . $_type . '::share'),
+			config::byKey('samba::' . $_type . '::username') . '%' . config::byKey('samba::' . $_type . '::password'),
+			config::byKey('samba::' . $_type . '::ip'),
+			$_cmd
+		);
 	}
 
 	public static function sortByDatetime($a, $b) {
@@ -189,7 +194,7 @@ class repo_samba {
 
 	public static function backup_send($_path) {
 		$pathinfo = pathinfo($_path);
-		$cmd = 'cd ' . $pathinfo['dirname'] . ';';
+		$cmd = 'cd ' . escapeshellarg($pathinfo['dirname']) . ';';
 		$cmd .= self::makeSambaCommand('cd ' . config::byKey('samba::backup::folder') . ';put ' . $pathinfo['basename']);
 		com_shell::execute($cmd);
 		self::cleanBackupFolder();
@@ -207,18 +212,18 @@ class repo_samba {
 
 	public static function backup_restore($_backup) {
 		$backup_dir = calculPath(config::byKey('backup::path'));
-		$cmd = 'cd ' . $backup_dir . ';';
+		$cmd = 'cd ' . escapeshellarg($backup_dir) . ';';
 		$cmd .= self::makeSambaCommand('cd ' . config::byKey('samba::backup::folder') . ';get ' . $_backup);
 		com_shell::execute($cmd);
-		com_shell::execute(system::getCmdSudo() . 'chmod 777 -R ' . $backup_dir . '/*');
+		com_shell::execute(system::getCmdSudo() . 'chmod 777 -R ' . escapeshellarg($backup_dir) . '/*');
 	}
 
 	public static function downloadCore($_path) {
 		$pathinfo = pathinfo($_path);
-		$cmd = 'cd ' . $pathinfo['dirname'] . ';';
+		$cmd = 'cd ' . escapeshellarg($pathinfo['dirname']) . ';';
 		$cmd .= self::makeSambaCommand('get ' . config::byKey('samba::core::path') . '/jeedom.zip', 'plugin');
 		com_shell::execute($cmd);
-		com_shell::execute(system::getCmdSudo() . 'chmod 777 -R ' . $_path);
+		com_shell::execute(system::getCmdSudo() . 'chmod 777 -R ' . escapeshellarg($_path));
 		return;
 	}
 
@@ -234,7 +239,7 @@ class repo_samba {
 				return null;
 			}
 			$version = trim(file_get_contents(jeedom::getTmpFolder('samba') . '/version'));
-			com_shell::execute(system::getCmdSudo() . 'rm ' . jeedom::getTmpFolder('samba') . '/version');
+			com_shell::execute(system::getCmdSudo() . 'rm ' . escapeshellarg(jeedom::getTmpFolder('samba') . '/version'));
 			return $version;
 		} catch (Exception $e) {
 		} catch (Error $e) {

--- a/tests/php/utilsTest.php
+++ b/tests/php/utilsTest.php
@@ -98,4 +98,25 @@ class utilsTest extends TestCase {
 	public function testCleanPath($in, $out) {
 		$this->assertSame($out, cleanPath($in));
 	}
+
+	public function testShellSmbclientCommandEscapesShare() {
+		$cmd = shellSmbclientCommand('//host/share; rm -rf /', 'user%pass', '1.2.3.4', 'ls');
+		$this->assertStringContainsString("'//host/share; rm -rf /'", $cmd);
+		$this->assertStringNotContainsString('//host/share; rm -rf / -U', $cmd);
+	}
+
+	public function testShellSmbclientCommandEscapesUserPassword() {
+		$cmd = shellSmbclientCommand('//host/share', "user%pass'; evil; '", '1.2.3.4', 'ls');
+		$this->assertStringContainsString("-U '" . str_replace("'", "'\\''", "user%pass'; evil; '") . "'", $cmd);
+	}
+
+	public function testShellSmbclientCommandEscapesIp() {
+		$cmd = shellSmbclientCommand('//host/share', 'user%pass', '1.2.3.4 -F /etc/passwd', 'ls');
+		$this->assertStringContainsString("-I '1.2.3.4 -F /etc/passwd'", $cmd);
+	}
+
+	public function testShellSmbclientCommandEscapesInnerCmd() {
+		$cmd = shellSmbclientCommand('//host/share', 'user%pass', '1.2.3.4', 'cd foo;ls" -c "evil');
+		$this->assertStringEndsWith("-c 'cd foo;ls\" -c \"evil'", $cmd);
+	}
 }


### PR DESCRIPTION
makeSambaCommand() concaténait share, username, password, ip et la sous-commande Samba dans une string smbclient sans escapeshellarg. Plusieurs appelants composaient en plus leur propre `cd \$path;cmd` ou `mv/chmod/rm \$path` sans escape. Un admin compromis pouvait obtenir une RCE en injectant des caractères spéciaux dans n'importe quelle config samba::* ou dans backup::path.

Helper shellSmbclientCommand(\$share, \$userPassword, \$ip, \$innerCmd) ajouté à utils.inc.php pour centraliser l'échappement de la commande smbclient. Note : les sous-commandes Samba (cd/get/put/del/...) restent telles quelles côté smbclient — elles ne donnent pas accès au shell hôte ; un éventuel durcissement côté Samba est hors scope.

makeSambaCommand() délègue au nouveau helper. Tous les appelants ont escapeshellarg() ajouté autour des paths qu'ils concatènent côté shell hôte (cd, mv, chmod, rm).

Tests dans utilsTest.php (4 cas) couvrent share/userPassword/ip/cmd avec payloads classiques (\`; rm -rf /\`, guillemets, redirections).