### PR TITLE
Échapper les arguments shell d'install/backup.php

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,17 @@ function calculPath($_path) {
 	return $_path;
 }
 
+/**
+ * Build shell-safe MySQL CLI connection arguments (user, password, host/port or socket, database).
+ *
+ * @param string      $_host     MySQL host.
+ * @param int|string  $_port     MySQL TCP port.
+ * @param string      $_user     MySQL user.
+ * @param string      $_password MySQL password.
+ * @param string      $_dbname   Database name.
+ * @param string|null $_socket   Optional Unix socket path; takes precedence over host/port when set.
+ * @return string Space-separated argument string for mysql/mysqldump.
+ */
 function shellMysqlConnectionArgs($_host, $_port, $_user, $_password, $_dbname, $_socket = null) {
 	if ($_socket !== null) {
 		$args = '--socket=' . escapeshellarg($_socket);
@@ -1030,6 +1041,14 @@ function shellMysqlConnectionArgs($_host, $_port, $_user, $_password, $_dbname, 
 	return $args;
 }
 
+/**
+ * Build a shell-safe `tar cfz` command that archives the current directory with optional excludes.
+ *
+ * @param string   $_workdir       Directory to cd into before taring (archived as `.`).
+ * @param string   $_outputArchive Output archive path (.tar.gz).
+ * @param string[] $_excludes      Patterns passed one per `--exclude=` flag.
+ * @return string Full shell command, ready for exec/shell_exec.
+ */
 function shellTarCreateCommand($_workdir, $_outputArchive, array $_excludes = []) {
 	$cmd = 'cd ' . escapeshellarg($_workdir) . ';tar cfz ' . escapeshellarg($_outputArchive);
 	foreach ($_excludes as $exclude) {

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1013,6 +1013,32 @@ function calculPath($_path) {
 	return $_path;
 }
 
+function shellMysqlConnectionArgs($_host, $_port, $_user, $_password, $_dbname, $_socket = null) {
+	if ($_socket !== null) {
+		$args = '--socket=' . escapeshellarg($_socket);
+	} elseif ($_host == 'localhost' && $_port == 3306) {
+		$args = '';
+	} else {
+		$args = '--host=' . escapeshellarg($_host) . ' --port=' . escapeshellarg((string) $_port);
+	}
+	if ($args !== '') {
+		$args .= ' ';
+	}
+	$args .= '--user=' . escapeshellarg($_user)
+		. ' --password=' . escapeshellarg($_password)
+		. ' ' . escapeshellarg($_dbname);
+	return $args;
+}
+
+function shellTarCreateCommand($_workdir, $_outputArchive, array $_excludes = []) {
+	$cmd = 'cd ' . escapeshellarg($_workdir) . ';tar cfz ' . escapeshellarg($_outputArchive);
+	foreach ($_excludes as $exclude) {
+		$cmd .= ' --exclude=' . escapeshellarg($exclude);
+	}
+	$cmd .= ' .';
+	return $cmd;
+}
+
 function getDirectorySize($path) {
 	$bytestotal = 0;
 	$path = realpath($path);

--- a/install/backup.php
+++ b/install/backup.php
@@ -78,15 +78,14 @@ try {
 	}
 
 
-	if (isset($CONFIG['db']['unix_socket'])) {
-		$str_db_connexion = "--socket=" . $CONFIG['db']['unix_socket'] . " --user=" . $CONFIG['db']['username'] . " --password='" . $CONFIG['db']['password'] . "' " . $CONFIG['db']['dbname'];
-	} else {
-		if ($CONFIG['db']['host'] == 'localhost' && $CONFIG['db']['port'] == 3306) {
-			$str_db_connexion = "--user=" . $CONFIG['db']['username'] . " --password='" . $CONFIG['db']['password'] . "' " . $CONFIG['db']['dbname'];
-		} else {
-			$str_db_connexion = "--host=" . $CONFIG['db']['host'] . " --port=" . $CONFIG['db']['port'] . " --user=" . $CONFIG['db']['username'] . " --password='" . $CONFIG['db']['password'] . "' " . $CONFIG['db']['dbname'];
-		}
-	}
+	$str_db_connexion = shellMysqlConnectionArgs(
+		$CONFIG['db']['host'] ?? 'localhost',
+		$CONFIG['db']['port'] ?? 3306,
+		$CONFIG['db']['username'],
+		$CONFIG['db']['password'],
+		$CONFIG['db']['dbname'],
+		$CONFIG['db']['unix_socket'] ?? null
+	);
 	$tables = DB::Prepare("SHOW TABLES", array(), DB::FETCH_TYPE_ALL);
 	foreach ($tables as $table) {
 		$table = array_values($table)[0];
@@ -94,7 +93,7 @@ try {
 			continue;
 		}
 		echo "Checking  table " . $table . "...";
-		system("mysqlcheck " . $str_db_connexion . ' --auto-repair --silent --tables ' . $table);
+		system("mysqlcheck " . $str_db_connexion . ' --auto-repair --silent --tables ' . escapeshellarg($table));
 		echo "OK" . "\n";
 	}
 
@@ -102,13 +101,13 @@ try {
 	if (file_exists($jeedom_dir . "/DB_backup.sql")) {
 		unlink($jeedom_dir . "/DB_backup.sql");
 		if (file_exists($jeedom_dir . "/DB_backup.sql")) {
-			system("sudo rm " . $jeedom_dir . "/DB_backup.sql");
+			system("sudo rm " . escapeshellarg($jeedom_dir . "/DB_backup.sql"));
 		}
 	}
 	if (file_exists($jeedom_dir . "/DB_backup.sql")) {
 		throw new Exception('can\'t delete database backup. Check rights');
 	}
-	system("mysqldump " . $str_db_connexion . "  > " . $jeedom_dir . "/DB_backup.sql", $rc);
+	system("mysqldump " . $str_db_connexion . " > " . escapeshellarg($jeedom_dir . "/DB_backup.sql"), $rc);
 
 	if ($rc != 0) {
 		throw new Exception('Backing up database failed. Check mysqldump installation. Code: ' . $rc);
@@ -175,11 +174,7 @@ try {
 	}
 
 
-	$exclude = '';
-	foreach ($excludes as $folder) {
-		$exclude .= ' --exclude="' . $folder . '"';
-	}
-	system('cd ' . $jeedom_dir . ';tar cfz "' . $backup_dir . '/' . $backup_name . '" ' . $exclude . ' . > /dev/null');
+	system(shellTarCreateCommand($jeedom_dir, $backup_dir . '/' . $backup_name, $excludes) . ' > /dev/null');
 	echo "OK" . "\n";
 
 	if (!file_exists($backup_dir . '/' . $backup_name)) {
@@ -187,7 +182,7 @@ try {
 	}
 
 	echo 'Cleaning old backup...';
-	shell_exec('find "' . $backup_dir . '" -name "*.gz" -mtime +' . config::byKey('backup::keepDays') . ' -delete');
+	shell_exec('find ' . escapeshellarg($backup_dir) . ' -name "*.gz" -mtime +' . escapeshellarg((string) config::byKey('backup::keepDays')) . ' -delete');
 	echo "OK" . "\n";
 
 	global $NO_CLOUD_BACKUP;

--- a/tests/php/utilsTest.php
+++ b/tests/php/utilsTest.php
@@ -98,4 +98,55 @@ class utilsTest extends TestCase {
 	public function testCleanPath($in, $out) {
 		$this->assertSame($out, cleanPath($in));
 	}
+
+	public function testShellMysqlConnectionArgsWithSocket() {
+		$args = shellMysqlConnectionArgs('localhost', 3306, 'root', 'pwd', 'mydb', '/var/run/mysqld/mysqld.sock');
+		$this->assertStringContainsString("--socket='/var/run/mysqld/mysqld.sock'", $args);
+		$this->assertStringNotContainsString('--host', $args);
+		$this->assertStringNotContainsString('--port', $args);
+	}
+
+	public function testShellMysqlConnectionArgsLocalhostDefaultPort() {
+		$args = shellMysqlConnectionArgs('localhost', 3306, 'root', 'pwd', 'mydb');
+		$this->assertStringNotContainsString('--host', $args);
+		$this->assertStringNotContainsString('--port', $args);
+		$this->assertStringContainsString("--user='root'", $args);
+		$this->assertStringContainsString("--password='pwd'", $args);
+		$this->assertStringEndsWith("'mydb'", $args);
+	}
+
+	public function testShellMysqlConnectionArgsRemoteHost() {
+		$args = shellMysqlConnectionArgs('db.internal', 33306, 'root', 'pwd', 'mydb');
+		$this->assertStringContainsString("--host='db.internal'", $args);
+		$this->assertStringContainsString("--port='33306'", $args);
+	}
+
+	public function testShellMysqlConnectionArgsEscapesPassword() {
+		$args = shellMysqlConnectionArgs('localhost', 3306, 'root', "p; rm -rf /; '", 'mydb');
+		$this->assertStringContainsString("--password='" . str_replace("'", "'\\''", "p; rm -rf /; '") . "'", $args);
+	}
+
+	public function testShellMysqlConnectionArgsEscapesDbname() {
+		$args = shellMysqlConnectionArgs('localhost', 3306, 'root', 'pwd', 'mydb; cat /etc/passwd');
+		$this->assertStringEndsWith("'mydb; cat /etc/passwd'", $args);
+	}
+
+	public function testShellTarCreateCommandBasic() {
+		$cmd = shellTarCreateCommand('/var/www', '/backup/out.tar.gz', []);
+		$this->assertStringContainsString("cd '/var/www'", $cmd);
+		$this->assertStringContainsString("tar cfz '/backup/out.tar.gz'", $cmd);
+		$this->assertStringEndsWith(' .', $cmd);
+	}
+
+	public function testShellTarCreateCommandWithExcludes() {
+		$cmd = shellTarCreateCommand('/var/www', '/backup/out.tar.gz', ['tmp', './log; evil', 'docs']);
+		$this->assertStringContainsString("--exclude='tmp'", $cmd);
+		$this->assertStringContainsString("--exclude='./log; evil'", $cmd);
+		$this->assertStringContainsString("--exclude='docs'", $cmd);
+	}
+
+	public function testShellTarCreateCommandEscapesOutputArchive() {
+		$cmd = shellTarCreateCommand('/var/www', '/backup/out"; evil; ".tar.gz', []);
+		$this->assertStringContainsString("'/backup/out\"; evil; \".tar.gz'", $cmd);
+	}
 }


### PR DESCRIPTION
Le script entrypoint construisait \$str_db_connexion par concat brute des configs DB (host/port/user/password/dbname/socket) puis mysqlcheck/mysqldump y enchaînait des paths sans escape. tar et find sur le dossier de backup combinaient encore une fois des configs admin (backup::path, backup::keepDays, name) sans escape. Un admin compromis pouvait obtenir une RCE en injectant des caractères spéciaux dans n'importe laquelle de ces configs.

2 helpers dans utils.inc.php :
- shellMysqlConnectionArgs(\$host, \$port, \$user, \$password, \$dbname, \$socket = null) reproduit la logique des 3 branches (socket / localhost+3306 / remote) et échappe chaque argument.
- shellTarCreateCommand(\$workdir, \$outputArchive, \$excludes = []) remplace la concat \"cd \$dir;tar cfz '\$out' --exclude=\\\"...\\\"\".

install/backup.php : appel à mysqlcheck escape le nom de table, à mysqldump escape la cible, à find escape le dossier et keepDays, et \"sudo rm\" escape son argument.

Tests dans utilsTest.php (8 cas) couvrant les 3 modes de connexion, l'échappement des configs, et le rendu de tar avec/sans excludes et sur des chemins malicieux.