### PR TITLE
Échapper les arguments shell de downloadFile.php

### DIFF
--- a/core/php/downloadFile.php
+++ b/core/php/downloadFile.php
@@ -80,7 +80,7 @@ try {
 		if (!$isAdmin) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		// `*` reste non quoté pour laisser le shell faire l'expansion glob après le `cd`.
+		// `*` is intentionally left unquoted so the shell performs glob expansion after `cd`.
 		system('cd ' . escapeshellarg(dirname($pathfile)) . ';tar cfz ' . escapeshellarg(jeedom::getTmpFolder('downloads') . '/archive.tar.gz') . ' * > /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';
 	} else {

--- a/core/php/downloadFile.php
+++ b/core/php/downloadFile.php
@@ -80,14 +80,15 @@ try {
 		if (!$isAdmin) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz * > /dev/null 2>&1');
+		// `*` reste non quoté pour laisser le shell faire l'expansion glob après le `cd`.
+		system('cd ' . escapeshellarg(dirname($pathfile)) . ';tar cfz ' . escapeshellarg(jeedom::getTmpFolder('downloads') . '/archive.tar.gz') . ' * > /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';
 	} else {
 		if (!$isAdmin) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		$pattern = array_pop(explode('/', $pathfile));
-		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz ' . $pattern . '> /dev/null 2>&1');
+		system('cd ' . escapeshellarg(dirname($pathfile)) . ';tar cfz ' . escapeshellarg(jeedom::getTmpFolder('downloads') . '/archive.tar.gz') . ' ' . escapeshellarg($pattern) . ' > /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';
 	}
 	ob_clean();


### PR DESCRIPTION
Les deux appels à system() qui créent une archive tar concaténaient dirname(\$pathfile), le chemin tmp et \$pattern (basename) sans escapeshellarg. \$pathfile vient indirectement de init('pathfile') — même si la résolution préalable via realpath limite les vecteurs, des caractères spéciaux dans le chemin résolu permettent une RCE.

Inline avec escapeshellarg sur les paths variables. Le `*` du premier appel reste non quoté pour préserver l'expansion glob shell, avec un commentaire pour expliquer.