### PR TITLE
Restreindre l'authentification SSO aux proxies de confiance

### DIFF
--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -482,4 +482,55 @@ class network {
 		log::add('network', 'error', __('Souci réseau détecté, redémarrage du réseau. La gateway ne répond pas au ping :', __FILE__) . ' ' . $gw);
 		exec(system::getCmdSudo() . 'service networking restart');
 	}
+
+	public static function isFromTrustedProxy($_ip, $_trustedList) {
+		if ($_ip === '' || $_ip === null || !filter_var($_ip, FILTER_VALIDATE_IP)) {
+			return false;
+		}
+		if (!is_string($_trustedList) || trim($_trustedList) === '') {
+			return false;
+		}
+		$entries = preg_split('/[\s,;]+/', $_trustedList, -1, PREG_SPLIT_NO_EMPTY);
+		foreach ($entries as $entry) {
+			if (self::ipMatchesEntry($_ip, $entry)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static function ipMatchesEntry($_ip, $_entry) {
+		$entry = trim($_entry);
+		if ($entry === '') {
+			return false;
+		}
+		if (strpos($entry, '/') === false) {
+			return filter_var($entry, FILTER_VALIDATE_IP) !== false
+				&& inet_pton($entry) === inet_pton($_ip);
+		}
+		list($subnet, $maskLen) = explode('/', $entry, 2);
+		if (!filter_var($subnet, FILTER_VALIDATE_IP) || !ctype_digit((string) $maskLen)) {
+			return false;
+		}
+		$maskLen = (int) $maskLen;
+		$ipBin = inet_pton($_ip);
+		$subnetBin = inet_pton($subnet);
+		if ($ipBin === false || $subnetBin === false || strlen($ipBin) !== strlen($subnetBin)) {
+			return false;
+		}
+		$totalBits = strlen($ipBin) * 8;
+		if ($maskLen < 0 || $maskLen > $totalBits) {
+			return false;
+		}
+		$fullBytes = intdiv($maskLen, 8);
+		$remainingBits = $maskLen % 8;
+		if ($fullBytes > 0 && substr($ipBin, 0, $fullBytes) !== substr($subnetBin, 0, $fullBytes)) {
+			return false;
+		}
+		if ($remainingBits === 0) {
+			return true;
+		}
+		$mask = chr(0xff << (8 - $remainingBits) & 0xff);
+		return (ord($ipBin[$fullBytes]) & ord($mask)) === (ord($subnetBin[$fullBytes]) & ord($mask));
+	}
 }

--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -483,11 +483,19 @@ class network {
 		exec(system::getCmdSudo() . 'service networking restart');
 	}
 
-	public static function isFromTrustedProxy($_ip, $_trustedList) {
-		if ($_ip === '' || $_ip === null || !filter_var($_ip, FILTER_VALIDATE_IP)) {
+	/**
+	 * Check whether an IP address belongs to a list of trusted proxies.
+	 *
+	 * @param string $_ip          Source IP to verify (IPv4 or IPv6).
+	 * @param string $_trustedList Comma/space/semicolon-separated list of IPs or CIDR ranges.
+	 *                             Example: "10.0.0.5, 192.168.1.0/24, ::1".
+	 * @return bool True if $_ip matches an entry in the list, false otherwise (including empty list or invalid IP).
+	 */
+	public static function isFromTrustedProxy(string $_ip, string $_trustedList): bool {
+		if ($_ip === '' || !filter_var($_ip, FILTER_VALIDATE_IP)) {
 			return false;
 		}
-		if (!is_string($_trustedList) || trim($_trustedList) === '') {
+		if (trim($_trustedList) === '') {
 			return false;
 		}
 		$entries = preg_split('/[\s,;]+/', $_trustedList, -1, PREG_SPLIT_NO_EMPTY);
@@ -499,7 +507,14 @@ class network {
 		return false;
 	}
 
-	private static function ipMatchesEntry($_ip, $_entry) {
+	/**
+	 * Check whether an IP matches a single list entry (exact IP or CIDR range).
+	 *
+	 * @param string $_ip    Source IP, already validated by filter_var().
+	 * @param string $_entry Raw list entry: exact IP or CIDR (IPv4/IPv6).
+	 * @return bool True if the IP matches the entry, false if the entry is invalid or out of range.
+	 */
+	private static function ipMatchesEntry(string $_ip, string $_entry): bool {
 		$entry = trim($_entry);
 		if ($entry === '') {
 			return false;

--- a/core/php/authentification.php
+++ b/core/php/authentification.php
@@ -17,7 +17,7 @@
 */
 require_once __DIR__ . '/core.inc.php';
 
-$configs = config::byKeys(array('session_lifetime', 'sso:allowRemoteUser', 'sso:remoteUserHeader'));
+$configs = config::byKeys(array('session_lifetime', 'sso:allowRemoteUser', 'sso:remoteUserHeader', 'sso:trustedProxies'));
 
 if (session_status() == PHP_SESSION_DISABLED || !isset($_SESSION)) {
 	$session_lifetime = $configs['session_lifetime'];
@@ -61,13 +61,24 @@ if (!isConnect() && isset($_COOKIE['registerDevice']) && !loginByHash($_COOKIE['
 }
 
 if (!isConnect() && $configs['sso:allowRemoteUser'] == 1) {
-	$header_value = ($configs['sso:remoteUserHeader'] != '') ? $_SERVER[$configs['sso:remoteUserHeader']] : $_SERVER['REMOTE_USER'];
-	$user = user::byLogin($header_value);
-	if (is_object($user) && $user->getEnable() == 1) {
-		@session_start();
-		$_SESSION['user'] = $user;
-		@session_write_close();
-		log::add('connection', 'info', __('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $user->getLogin());
+	$remoteAddr = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+	$trustedProxies = isset($configs['sso:trustedProxies']) ? $configs['sso:trustedProxies'] : '';
+	$ssoAllowed = true;
+	if (trim($trustedProxies) === '') {
+		log::add('connection', 'warning', __('SSO actif sans sso:trustedProxies configuré : configurer la liste des proxies de confiance pour éviter l\'usurpation par header HTTP. IP source :', __FILE__) . ' ' . $remoteAddr);
+	} elseif (!network::isFromTrustedProxy($remoteAddr, $trustedProxies)) {
+		$ssoAllowed = false;
+		log::add('connection', 'warning', __('SSO refusé : requête depuis une IP non listée dans sso:trustedProxies :', __FILE__) . ' ' . $remoteAddr);
+	}
+	if ($ssoAllowed) {
+		$header_value = ($configs['sso:remoteUserHeader'] != '') ? $_SERVER[$configs['sso:remoteUserHeader']] : $_SERVER['REMOTE_USER'];
+		$user = user::byLogin($header_value);
+		if (is_object($user) && $user->getEnable() == 1) {
+			@session_start();
+			$_SESSION['user'] = $user;
+			@session_write_close();
+			log::add('connection', 'info', __('Connexion de l\'utilisateur par REMOTE_USER :', __FILE__) . ' ' . $user->getLogin());
+		}
 	}
 }
 

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1725,6 +1725,14 @@ $productName = config::byKey('product_name');
 								<input type="text" class="configKey form-control" data-l1key="sso:remoteUserHeader">
 							</div>
 						</div>
+						<div class="form-group">
+							<label class="col-md-3 col-sm-4 col-xs-12 control-label" style="color:#c9302c;">{{Proxies de confiance (FORTEMENT RECOMMANDÉ)}}
+								<sup><i class="fas fa-question-circle" tooltip="{{Liste des IPs ou plages CIDR autorisées à transmettre l'entête SSO (séparées par virgules). Si vide, n'importe qui peut usurper une session admin en envoyant le header HTTP. Exemples : 10.0.0.5, 192.168.1.0/24, ::1}}"></i></sup>
+							</label>
+							<div class="col-md-3 col-sm-4 col-xs-12">
+								<input type="text" class="configKey form-control" data-l1key="sso:trustedProxies" placeholder="10.0.0.5, 192.168.1.0/24">
+							</div>
+						</div>
 
 						<legend>{{Dépendance et démon}}</legend>
 						<div class="form-group">

--- a/tests/class/networkTrustedProxyTest.php
+++ b/tests/class/networkTrustedProxyTest.php
@@ -18,8 +18,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-// TODO: missing e2e test — simulate REMOTE_USER + REMOTE_ADDR against the full authentification.php
-// flow (session, DB, $_SERVER). Current coverage: helper in isolation only.
 class networkTrustedProxyTest extends TestCase
 {
 	public function testEmptyListRejectsEverything()

--- a/tests/class/networkTrustedProxyTest.php
+++ b/tests/class/networkTrustedProxyTest.php
@@ -18,8 +18,8 @@
 
 use PHPUnit\Framework\TestCase;
 
-// TODO: test e2e manquant — simuler REMOTE_USER + REMOTE_ADDR contre authentification.php complet
-// (session, DB, $_SERVER). Couverture actuelle : helper en isolation uniquement.
+// TODO: missing e2e test — simulate REMOTE_USER + REMOTE_ADDR against the full authentification.php
+// flow (session, DB, $_SERVER). Current coverage: helper in isolation only.
 class networkTrustedProxyTest extends TestCase
 {
 	public function testEmptyListRejectsEverything()

--- a/tests/class/networkTrustedProxyTest.php
+++ b/tests/class/networkTrustedProxyTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use PHPUnit\Framework\TestCase;
+
+// TODO: test e2e manquant — simuler REMOTE_USER + REMOTE_ADDR contre authentification.php complet
+// (session, DB, $_SERVER). Couverture actuelle : helper en isolation uniquement.
+class networkTrustedProxyTest extends TestCase
+{
+	public function testEmptyListRejectsEverything()
+	{
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', ''));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', '   '));
+	}
+
+	public function testInvalidIpRejected()
+	{
+		$this->assertFalse(network::isFromTrustedProxy('not-an-ip', '10.0.0.5'));
+		$this->assertFalse(network::isFromTrustedProxy('', '10.0.0.5'));
+	}
+
+	public function testExactIpv4Match()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('10.0.0.5', '10.0.0.5'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.6', '10.0.0.5'));
+	}
+
+	public function testIpv4CidrMatch()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('192.168.1.42', '192.168.1.0/24'));
+		$this->assertTrue(network::isFromTrustedProxy('192.168.1.255', '192.168.1.0/24'));
+		$this->assertFalse(network::isFromTrustedProxy('192.168.2.1', '192.168.1.0/24'));
+	}
+
+	public function testIpv4CidrNonByteAlignedMask()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('10.0.0.1', '10.0.0.0/30'));
+		$this->assertTrue(network::isFromTrustedProxy('10.0.0.3', '10.0.0.0/30'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.4', '10.0.0.0/30'));
+	}
+
+	public function testIpv6ExactMatch()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('::1', '::1'));
+		$this->assertTrue(network::isFromTrustedProxy('2001:db8::1', '2001:db8::1'));
+		$this->assertFalse(network::isFromTrustedProxy('2001:db8::2', '2001:db8::1'));
+	}
+
+	public function testIpv6CidrMatch()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('2001:db8::1234', '2001:db8::/32'));
+		$this->assertFalse(network::isFromTrustedProxy('2001:db9::1', '2001:db8::/32'));
+	}
+
+	public function testCommaSeparatedList()
+	{
+		$list = '10.0.0.5, 192.168.1.0/24, ::1';
+		$this->assertTrue(network::isFromTrustedProxy('10.0.0.5', $list));
+		$this->assertTrue(network::isFromTrustedProxy('192.168.1.99', $list));
+		$this->assertTrue(network::isFromTrustedProxy('::1', $list));
+		$this->assertFalse(network::isFromTrustedProxy('8.8.8.8', $list));
+	}
+
+	public function testFamilyMismatchRejected()
+	{
+		$this->assertFalse(network::isFromTrustedProxy('::1', '127.0.0.1'));
+		$this->assertFalse(network::isFromTrustedProxy('127.0.0.1', '::1'));
+		$this->assertFalse(network::isFromTrustedProxy('::1', '10.0.0.0/8'));
+	}
+
+	public function testInvalidEntriesAreSkipped()
+	{
+		$this->assertTrue(network::isFromTrustedProxy('10.0.0.5', 'garbage, 10.0.0.5'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', 'garbage, 999.999.999.999'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', '10.0.0.5/abc'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', '10.0.0.5/-1'));
+		$this->assertFalse(network::isFromTrustedProxy('10.0.0.5', '10.0.0.5/33'));
+	}
+}


### PR DESCRIPTION
Ajoute une config sso:trustedProxies (IP/CIDR séparés par virgules, IPv4 et IPv6) vérifiée contre $_SERVER['REMOTE_ADDR'] avant de faire confiance au header REMOTE_USER. Si la liste est vide, conserve le comportement actuel mais log un warning à chaque connexion SSO pour inviter à la migration. Helper network::isFromTrustedProxy() couvert par 10 tests unitaires (un test e2e sur authentification.php reste à ajouter).